### PR TITLE
Add checkbox for showing only responses with obs

### DIFF
--- a/ertviz/controllers/multi_response_controller.py
+++ b/ertviz/controllers/multi_response_controller.py
@@ -88,13 +88,23 @@ def _create_response_plot(response, plot_type, selected_realizations, color):
     return ensemble_plot
 
 
+def _valid_response_option(response_filters, response):
+    if "obs" in response_filters:
+        return response.observations
+    else:
+        return True
+
+
 def multi_response_controller(parent, app):
     @app.callback(
         Output({"index": ALL, "type": parent.uuid("response-selector")}, "options"),
-        [Input(parent.uuid("ensemble-selection-store"), "data")],
+        [
+            Input(parent.uuid("ensemble-selection-store"), "data"),
+            Input(parent.uuid("response-observations-check"), "value"),
+        ],
         [State({"index": ALL, "type": parent.uuid("response-selector")}, "options")],
     )
-    def _set_response_options(selected_ensembles, selectors):
+    def _set_response_options(selected_ensembles, response_filters, selectors):
         # Should either return a union of all possible responses or the other thing which I cant think of...
         if not selected_ensembles:
             raise PreventUpdate
@@ -107,6 +117,9 @@ def multi_response_controller(parent, app):
                     "value": response,
                 }
                 for response in ensemble.responses
+                if _valid_response_option(
+                    response_filters, ensemble.responses[response]
+                )
             ]
             for i in range(len(selectors))
         ]

--- a/ertviz/controllers/observation_response_controller.py
+++ b/ertviz/controllers/observation_response_controller.py
@@ -60,6 +60,7 @@ def observation_response_controller(parent, app):
                 "value": response,
             }
             for response in ensemble.responses
+            if ensemble.responses[response].observations
         ]
 
     @app.callback(

--- a/ertviz/views/__init__.py
+++ b/ertviz/views/__init__.py
@@ -15,6 +15,16 @@ def response_view(parent, index=0):
                     id={"index": index, "type": parent.uuid("response-selector")},
                     className="ert-dropdown",
                 ),
+                dcc.Checklist(
+                    id=parent.uuid("response-observations-check"),
+                    options=[
+                        {
+                            "label": "Show only responses with observations",
+                            "value": "obs",
+                        },
+                    ],
+                    value=[],
+                ),
             ],
         ),
         html.Div(


### PR DESCRIPTION
Resolves #80 

Instead of highlighting the responses with observations as suggested in the issue, a checkbox is added such that only the responses with observations is shown when checked. 