### PR TITLE
Replace datetime.fromisoformat()

### DIFF
--- a/ertviz/models/__init__.py
+++ b/ertviz/models/__init__.py
@@ -1,8 +1,8 @@
-from datetime import datetime
+import dateutil.parser
 
 
 def _convertdate(dstring):
-    return datetime.fromisoformat(dstring)
+    return dateutil.parser.isoparse(dstring)
 
 
 def indexes_to_axis(indexes):


### PR DESCRIPTION
datetime.fromisoformat() is new in python 3.7 and does not run in
python<3.7.