### PR TITLE
Convert datetime64 to float64 before adding to df

### DIFF
--- a/ertviz/models/response.py
+++ b/ertviz/models/response.py
@@ -61,9 +61,11 @@ class Response:
             }
         if bool(data):
             misfits_df = pd.DataFrame(data=data)
-            misfits_df["x_axis"] = self.observations[0].data_df()["x_axis"]
+            misfits_df["x_axis"] = (
+                self.observations[0].data_df()["x_axis"].values.astype("float64")
+            )
             misfits_df.index.name = self.name
-            return misfits_df.astype("float64")
+            return misfits_df
         return None
 
     def summary_misfits_df(self, selection=None):


### PR DESCRIPTION
#98 
For some responses, the x_axis contains a datetime64. Pandas can not
convert datetime64 to float. Therefore, extract the date as a numpy
array and convert to float before adding to pandas dataframe.