### PR TITLE
Refactor data loader tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,9 +20,6 @@ jobs:
       run: |
         pip install .
         pip install -r test_requirements.txt
-    - name: Prepare Selenium
-      # https://github.com/marketplace/actions/setup-chromedriver
-      uses: nanasess/setup-chromedriver@master
     - name: Test with pytest
       run: |
         pytest

--- a/ertviz/data_loader/__init__.py
+++ b/ertviz/data_loader/__init__.py
@@ -4,6 +4,10 @@ import logging
 import pandas
 
 
+def _requests_get(*args, **kwargs):
+    return requests.get(*args, **kwargs)
+
+
 def get_info(project_id=None):
     from ert_shared.storage.connection import get_info
 
@@ -23,7 +27,7 @@ def get_auth(project_id=None):
 
 
 def get_csv_data(data_url, project_id=None):
-    response = requests.get(data_url, auth=get_auth(project_id), stream=True)
+    response = _requests_get(data_url, auth=get_auth(project_id), stream=True)
     response.raise_for_status()
     return pandas.read_csv(response.raw, names=["value"])
 
@@ -70,7 +74,7 @@ def get_parameter_data_url(ensemble_id, parameter_id, project_id=None):
 
 def get_schema(api_url, project_id=None):
     logging.info(f"Getting json from {api_url}...")
-    http_response = requests.get(api_url, auth=get_auth(project_id))
+    http_response = _requests_get(api_url, auth=get_auth(project_id))
     http_response.raise_for_status()
 
     logging.info(" done!")

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ with open("README.md", "r") as fh:
     LONG_DESCRIPTION = fh.read()
 
 TESTS_REQUIRE = [
-    "selenium~=3.141",
-    "pylint",
-    "mock",
-    "black",
     "bandit",
+    "black",
     "dash[testing]",
+    "pylint",
+    "pytest-mock",
+    "selenium~=3.141",
 ]
 
 setup(

--- a/tests/controllers/test_controller_functions.py
+++ b/tests/controllers/test_controller_functions.py
@@ -1,31 +1,8 @@
-from unittest import mock
 from ertviz.models.ensemble_model import EnsembleModel
 from ertviz.controllers.controller_functions import response_options
-from tests.conftest import (
-    mocked_requests_get,
-    mocked_read_csv,
-    mocked_get_info,
-    mocked_get_ensemble_url,
-    mocked_get_response_url,
-)
 
 
-@mock.patch("ertviz.data_loader.requests.get", side_effect=mocked_requests_get)
-@mock.patch("ertviz.data_loader.pandas.read_csv", side_effect=mocked_read_csv)
-@mock.patch("ertviz.data_loader.get_info", side_effect=mocked_get_info)
-@mock.patch(
-    "ertviz.models.ensemble_model.get_ensemble_url", side_effect=mocked_get_ensemble_url
-)
-@mock.patch(
-    "ertviz.models.response.get_response_url", side_effect=mocked_get_response_url
-)
-def test_response_options(
-    mock_get,
-    mock_get_csv,
-    mock_get_info,
-    mocked_get_ensemble_url,
-    mocked_get_response_url,
-):
+def test_response_options(mock_data):
     ensemble3 = EnsembleModel(ensemble_id=3, project_id=None)
     ensemble4 = EnsembleModel(ensemble_id=4, project_id=None)
 

--- a/tests/models/test_ensemble_model.py
+++ b/tests/models/test_ensemble_model.py
@@ -1,21 +1,8 @@
-from unittest import mock
-from tests.conftest import (
-    mocked_requests_get,
-    mocked_read_csv,
-    mocked_get_info,
-    mocked_get_ensemble_url,
-)
 from ertviz.models import EnsembleModel
 from ertviz.data_loader import get_url
 
 
-@mock.patch("ertviz.data_loader.requests.get", side_effect=mocked_requests_get)
-@mock.patch("ertviz.data_loader.pandas.read_csv", side_effect=mocked_read_csv)
-@mock.patch("ertviz.data_loader.get_info", side_effect=mocked_get_info)
-@mock.patch(
-    "ertviz.models.ensemble_model.get_ensemble_url", side_effect=mocked_get_ensemble_url
-)
-def test_ensemble_model(mock_get, mock_get_csv, mock_get_info, mock_get_ensemble_url):
+def test_ensemble_model(mock_data):
     ens_model = EnsembleModel(ensemble_id=1, project_id=None)
     assert len(ens_model.children) == 1
     assert ens_model.children[0]._name == "default_smoother_update"

--- a/tests/models/test_response_model.py
+++ b/tests/models/test_response_model.py
@@ -1,15 +1,8 @@
-from unittest import mock
-from tests.conftest import mocked_requests_get, mocked_get_info, mocked_get_response_url
 from ertviz.data_loader import get_ensemble_url
 from ertviz.models import Response
 
 
-@mock.patch("ertviz.data_loader.requests.get", side_effect=mocked_requests_get)
-@mock.patch("ertviz.data_loader.get_info", side_effect=mocked_get_info)
-@mock.patch(
-    "ertviz.models.response.get_response_url", side_effect=mocked_get_response_url
-)
-def test_ensemble_model(mock_get, mock_get_info, mock_get_response_url):
+def test_ensemble_model(mock_data):
     resp_model = Response(
         "SNAKE_OIL_GPR_DIFF",
         ensemble_id=1,

--- a/tests/plots/test_controller.py
+++ b/tests/plots/test_controller.py
@@ -1,7 +1,5 @@
 import pandas as pd
 import numpy as np
-from unittest import mock
-from tests.conftest import mocked_get_info, mocked_requests_get, mocked_get_ensemble_url
 from ertviz.controllers.multi_response_controller import (
     _get_observation_plots,
     _get_realizations_plots,
@@ -74,14 +72,7 @@ def test_realizations_statistics_plot_representation():
     np.testing.assert_equal(plots[2].repr.y, np.quantile(data, 0.9, axis=1))
 
 
-@mock.patch("ertviz.data_loader.requests.get", side_effect=mocked_requests_get)
-@mock.patch("ertviz.data_loader.get_info", side_effect=mocked_get_info)
-@mock.patch(
-    "ertviz.models.ensemble_model.get_ensemble_url", side_effect=mocked_get_ensemble_url
-)
-def test_ensemble_selector_graph_constructor(
-    mock_request, mock_get_info, mock_get_ensemble_url
-):
+def test_ensemble_selector_graph_constructor(mock_data):
     ensemble_dict = get_ensembles(project_id=None)
     ensemble_models = {
         schema["id"]: EnsembleModel(schema["id"], project_id=None)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,11 +1,6 @@
-from unittest import mock
-import tests.conftest
-from tests.conftest import mocked_requests_get, mocked_get_info
 from ertviz.data_loader import get_ensembles
 
 
-@mock.patch("ertviz.data_loader.requests.get", side_effect=mocked_requests_get)
-@mock.patch("ertviz.data_loader.get_info", side_effect=mocked_get_info)
-def test_get_ensembles(mock_request_get, mock_get_info):
+def test_get_ensembles(mock_data):
     ens = get_ensembles()
     assert len(ens) == 2

--- a/tests/views/test_ensemble_overview.py
+++ b/tests/views/test_ensemble_overview.py
@@ -1,30 +1,11 @@
 import dash
 import ertviz
-from unittest import mock
 from ertviz.plugins._ensemble_overview import EnsembleOverview
-from tests.data.snake_oil_data import ensembles_response
-from tests.conftest import (
-    mocked_requests_get,
-    mocked_read_csv,
-    mocked_get_info,
-    mocked_get_ensemble_url,
-)
 
 
-@mock.patch("ertviz.data_loader.requests.get", side_effect=mocked_requests_get)
-@mock.patch("ertviz.data_loader.pandas.read_csv", side_effect=mocked_read_csv)
-@mock.patch("ertviz.data_loader.get_info", side_effect=mocked_get_info)
-@mock.patch(
-    "ertviz.models.ensemble_model.get_ensemble_url", side_effect=mocked_get_ensemble_url
-)
 def test_ensemble_overview(
-    mock_get,
-    mock_get_csv,
-    mock_get_info,
-    mock_get_ensemble_url,
+    mock_data,
     dash_duo,
-    monkeypatch,
-    mocker,
 ):
     app = dash.Dash(__name__)
 

--- a/tests/views/test_parameter_selector.py
+++ b/tests/views/test_parameter_selector.py
@@ -1,26 +1,10 @@
 import dash
 import ertviz
-from unittest import mock
 from ertviz.plugins._parameter_comparison import ParameterComparison
-from tests.conftest import (
-    mocked_requests_get,
-    mocked_read_csv,
-    mocked_get_info,
-    mocked_get_ensemble_url,
-)
 
 
-@mock.patch("ertviz.data_loader.requests.get", side_effect=mocked_requests_get)
-@mock.patch("ertviz.data_loader.pandas.read_csv", side_effect=mocked_read_csv)
-@mock.patch("ertviz.data_loader.get_info", side_effect=mocked_get_info)
-@mock.patch(
-    "ertviz.models.ensemble_model.get_ensemble_url", side_effect=mocked_get_ensemble_url
-)
 def test_parameter_selector(
-    mock_get,
-    mock_get_csv,
-    mock_get_info,
-    mock_get_ensemble_url,
+    mock_data,
     dash_duo,
 ):
     app = dash.Dash(__name__)

--- a/tests/views/test_plot_view.py
+++ b/tests/views/test_plot_view.py
@@ -1,41 +1,11 @@
 import dash
 import ertviz
-from unittest import mock
 from ertviz.plugins._response_comparison import ResponseComparison
-from tests.data.snake_oil_data import ensembles_response
-from tests.conftest import (
-    mocked_requests_get,
-    mocked_read_csv,
-    mocked_get_info,
-    mocked_get_ensemble_url,
-    mocked_get_parameter_data_url,
-    mocked_get_response_url,
-)
 
 
-@mock.patch("ertviz.data_loader.requests.get", side_effect=mocked_requests_get)
-@mock.patch("ertviz.data_loader.pandas.read_csv", side_effect=mocked_read_csv)
-@mock.patch("ertviz.data_loader.get_info", side_effect=mocked_get_info)
-@mock.patch(
-    "ertviz.models.ensemble_model.get_ensemble_url", side_effect=mocked_get_ensemble_url
-)
-@mock.patch(
-    "ertviz.models.parameter_model.get_parameter_data_url",
-    side_effect=mocked_get_parameter_data_url,
-)
-@mock.patch(
-    "ertviz.models.response.get_response_url", side_effect=mocked_get_response_url
-)
 def test_plot_view(
-    mock_get,
-    mock_get_csv,
-    mock_get_info,
-    mock_get_ensemble_url,
-    mock_get_parameter_data_url,
-    mock_get_response_url,
+    mock_data,
     dash_duo,
-    monkeypatch,
-    mocker,
 ):
     # This test selects an ensemble from the ensemble-selector
     # then selects a response and parameter and checks that the


### PR DESCRIPTION
Simplify the mocking of data in preparation for refactoring of data loader itself.

Also remove chromedriver installation from Github Actions because the correct version is already installed in their `ubuntu-20.04` image.