### PR TITLE
Add support for reponses in selector component

### DIFF
--- a/ertviz/controllers/parameter_selector_controller.py
+++ b/ertviz/controllers/parameter_selector_controller.py
@@ -27,8 +27,11 @@ def parameter_selector_controller(parent, app):
             Input(parent.uuid("parameter-selector-filter"), "value"),
             Input(parent.uuid("parameter-deactivator"), "value"),
         ],
+        [State(parent.uuid("parameter-type-store"), "data")],
     )
-    def update_parameters_options(selected_ensembles, filter_search, selected):
+    def update_parameters_options(
+        selected_ensembles, filter_search, selected, store_type
+    ):
         if not selected_ensembles:
             raise PreventUpdate
         selected = [] if not selected else selected
@@ -36,11 +39,15 @@ def parameter_selector_controller(parent, app):
         params_included = None
         for ensemble_id, _ in selected_ensembles.items():
             ensemble = load_ensemble(parent, ensemble_id)
+            key_list = ensemble.responses
+            if store_type == "parameter":
+                key_list = ensemble.parameters
+
             if bool(filter_search):
                 parameters = set(
                     [
                         parameter_key
-                        for parameter_key in ensemble.parameters
+                        for parameter_key in key_list
                         if _filter_match(filter_search, parameter_key)
                         and parameter_key not in selected
                     ]
@@ -49,7 +56,7 @@ def parameter_selector_controller(parent, app):
                 parameters = set(
                     [
                         parameter_key
-                        for parameter_key in ensemble.parameters
+                        for parameter_key in key_list
                         if parameter_key not in selected
                     ]
                 )

--- a/ertviz/plugins/_parameter_comparison.py
+++ b/ertviz/plugins/_parameter_comparison.py
@@ -32,7 +32,7 @@ class ParameterComparison(WebvizPluginABC):
                     id=self.uuid("parallel-coor-content"),
                     children=[
                         html.H5("Multi parameter selector:"),
-                        parameter_selector_view(parent=self),
+                        parameter_selector_view(parent=self, data_type="parameter"),
                         parallel_coordinates_view(parent=self),
                     ],
                 ),

--- a/ertviz/views/selector_view.py
+++ b/ertviz/views/selector_view.py
@@ -4,7 +4,7 @@ import webviz_core_components as wcc
 import dash_bootstrap_components as dbc
 
 
-def parameter_selector_view(parent):
+def parameter_selector_view(parent, data_type="parameter"):
     return html.Div(
         [
             dbc.Row(
@@ -39,6 +39,11 @@ def parameter_selector_view(parent):
             ),
             dcc.Store(
                 id=parent.uuid("parameter-selection-store"), storage_type="session"
+            ),
+            dcc.Store(
+                id=parent.uuid("parameter-type-store"),
+                storage_type="session",
+                data=data_type,
             ),
         ],
     )


### PR DESCRIPTION
Resolves #122 

This adds an option to create selector with responses:
```python
parameter_selector_view(parent=self, data_type="response"),
```