### PR TITLE
Add Response correlation plugin

### DIFF
--- a/ertviz/assets/ert-style.json
+++ b/ertviz/assets/ert-style.json
@@ -28,7 +28,7 @@
             "rgba(240,2,127,0.8)",
             "rgba(191,91,23,0.8)"
         ],
-        "default_color" : "rgba(128,128,128,0.3)"
+        "default_color": "rgba(128,128,128,0.3)"
     },
     "observation-response-plot": {
         "observation": {
@@ -82,6 +82,14 @@
                 "size": 1
             }
         },
+        "response-index": {
+            "mode": "markers",
+            "line": null,
+            "marker": {
+                "color": "rgba(56,108,176,0.8)",
+                "size": 10
+            }
+        },
         "statistics": {
             "mode": "lines",
             "line": {
@@ -92,11 +100,11 @@
             "marker": null
         }
     },
-    "parameter-plot" : {
-        "prior" : {
-            "line" : {
-                "dash" : "dash",
-                "width" : 4
+    "parameter-plot": {
+        "prior": {
+            "line": {
+                "dash": "dash",
+                "width": 4
             }
         }
     },
@@ -111,6 +119,15 @@
                 "r": 5
             },
             "autosize": true
+        },
+        "legend-bellow": {
+            "showlegend": true,
+            "legend": {
+                "xanchor": "center",
+                "yanchor": "top",
+                "y": -0.3,
+                "x": 0.5
+            }
         }
     }
 }

--- a/ertviz/assets/webviz-config.yml
+++ b/ertviz/assets/webviz-config.yml
@@ -17,3 +17,7 @@ pages:
  - title: Parameter Comparison Viewer
    content:
     - ParameterComparison:
+
+ - title: Response Correlation Viewer
+   content:
+    - ResponseCorrelation:

--- a/ertviz/controllers/__init__.py
+++ b/ertviz/controllers/__init__.py
@@ -7,3 +7,4 @@ from .controller_functions import response_options, parameter_options
 from .plot_view_controller import plot_view_controller
 from .parameter_comparison_controller import parameter_comparison_controller
 from .parameter_selector_controller import parameter_selector_controller
+from .response_correlation_controller import response_correlation_controller

--- a/ertviz/controllers/multi_response_controller.py
+++ b/ertviz/controllers/multi_response_controller.py
@@ -8,9 +8,11 @@ from ertviz.controllers.controller_functions import response_options
 import ertviz.assets as assets
 
 
-def _get_realizations_plots(realizations_df, x_axis, color):
-    style = assets.ERTSTYLE["response-plot"]["response"].copy()
+def _get_realizations_plots(realizations_df, x_axis, color, style=None):
+    if not style:
+        style = assets.ERTSTYLE["response-plot"]["response"].copy()
     style.update({"line": {"color": color}})
+    style.update({"marker": {"color": color}})
     realizations_data = list()
     for realization in realizations_df:
         plot = PlotModel(
@@ -67,7 +69,9 @@ def _get_observation_plots(observation_df, x_axis):
     return [observation_data]
 
 
-def _create_response_plot(response, plot_type, selected_realizations, color):
+def _create_response_plot(
+    response, plot_type, selected_realizations, color, style=None
+):
 
     x_axis = response.axis
     if plot_type == "Statistics":
@@ -76,7 +80,7 @@ def _create_response_plot(response, plot_type, selected_realizations, color):
         )
     else:
         realizations = _get_realizations_plots(
-            response.data_df(selected_realizations), x_axis, color=color
+            response.data_df(selected_realizations), x_axis, color=color, style=style
         )
     observations = []
 

--- a/ertviz/controllers/response_correlation_controller.py
+++ b/ertviz/controllers/response_correlation_controller.py
@@ -1,0 +1,389 @@
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from copy import deepcopy
+from dash.exceptions import PreventUpdate
+from dash.dependencies import Input, Output, State
+import dash_core_components as dcc
+import dash_html_components as html
+import dash
+from ertviz.models import (
+    load_ensemble,
+    BarChartPlotModel,
+    PlotModel,
+)
+from ertviz.controllers.multi_response_controller import (
+    _get_observation_plots,
+)
+import ertviz.assets as assets
+
+
+def response_correlation_controller(parent, app):
+    @app.callback(
+        [
+            Output(
+                {
+                    "id": parent.uuid("response-correlation"),
+                    "type": parent.uuid("graph"),
+                },
+                "figure",
+            ),
+            Output(
+                {
+                    "id": parent.uuid("response-heatmap"),
+                    "type": parent.uuid("graph"),
+                },
+                "figure",
+            ),
+        ],
+        [
+            Input(parent.uuid("correlation-store-xindex"), "data"),
+            Input(parent.uuid("correlation-store-selection"), "data"),
+            Input(parent.uuid("correlation-metric"), "value"),
+        ],
+        [
+            State(parent.uuid("parameter-selection-store-param"), "data"),
+            State(parent.uuid("parameter-selection-store-resp"), "data"),
+            State(parent.uuid("ensemble-selection-store"), "data"),
+        ],
+    )
+    def update_correlation_plot(
+        corr_xindex,
+        corr_param_resp,
+        correlation_metric,
+        parameters,
+        responses,
+        ensembles,
+    ):
+        if not (
+            ensembles
+            and parameters
+            and responses
+            and corr_param_resp["response"] in responses
+        ):
+            raise PreventUpdate
+
+        selected_response = corr_param_resp["response"]
+        data = {}
+        colors = {}
+        heatmaps = []
+
+        df_index = None
+        for ensemble_id, color in ensembles.items():
+            ensemble = load_ensemble(parent, ensemble_id)
+            parameter_df = ensemble.parameters_df(parameters)
+            for response in responses:
+                response_df = ensemble.responses[response].data_df()
+                x_index = corr_xindex.get(response, 0)
+                parameter_df[response] = response_df.iloc[x_index]
+
+            corrdf = parameter_df.corr(method=correlation_metric)
+            corrdf = corrdf.drop(responses, axis=0).fillna(0)
+            if df_index is None:
+                df_index = corrdf[selected_response].abs().sort_values().index.copy()
+            corrdf = corrdf.reindex(df_index)
+            # create heatmap
+            data_heatmap = {
+                "type": "heatmap",
+                "x": corrdf[responses].columns,
+                "y": corrdf[responses].index,
+                "z": [
+                    corrdf[responses].loc[parameter].values
+                    for parameter in corrdf.index
+                ],
+                "zmin": -1,
+                "zmax": 1,
+                "colorscale": "rdylbu",
+                "reversescale": True,
+            }
+            heatmaps.append(data_heatmap)
+            ens_key = repr(ensemble)
+            data[ens_key] = corrdf[selected_response]
+            data[ens_key].index.name = selected_response
+            colors[ens_key] = color["color"]
+        if data and heatmaps:
+            parent.correlation_plot = BarChartPlotModel(data, colors)
+            parent.heatmap_plot = make_subplots(
+                rows=1,
+                cols=len(heatmaps),
+                subplot_titles=[f"ENS_{idx + 1}" for idx, _ in enumerate(heatmaps)],
+            )
+            for idx, heatmap in enumerate(heatmaps):
+                parent.heatmap_plot.add_trace(heatmap, 1, 1 + idx)
+                parent.heatmap_plot.update_yaxes(
+                    showticklabels=False, row=1, col=1 + idx
+                )
+                parent.heatmap_plot.update_xaxes(
+                    showticklabels=False, row=1, col=1 + idx
+                )
+            _layout = assets.ERTSTYLE["figure"]["layout"].copy()
+            _layout.update(
+                {
+                    "clickmode": "event+select",
+                    "showlegend": False,
+                    "annotations": [{"font": {"color": colors[ens]}} for ens in colors],
+                }
+            )
+            parent.heatmap_plot.update_layout(_layout)
+            return parent.correlation_plot.repr, parent.heatmap_plot
+
+    @app.callback(
+        Output(
+            {"id": parent.uuid("response-overview"), "type": parent.uuid("graph")},
+            "figure",
+        ),
+        [
+            Input(parent.uuid("correlation-store-xindex"), "modified_timestamp"),
+            Input(parent.uuid("parameter-selection-store-resp"), "modified_timestamp"),
+            Input(parent.uuid("ensemble-selection-store"), "modified_timestamp"),
+            Input(parent.uuid("correlation-store-selection"), "modified_timestamp"),
+        ],
+        [
+            State(parent.uuid("parameter-selection-store-resp"), "data"),
+            State(parent.uuid("ensemble-selection-store"), "data"),
+            State(parent.uuid("correlation-store-xindex"), "data"),
+            State(parent.uuid("correlation-store-selection"), "data"),
+        ],
+    )
+    def update_response_overview_plot(
+        _, __, ___, ____, responses, ensembles, corr_xindex, corr_param_resp
+    ):
+        if not (ensembles and responses and corr_param_resp["response"] in responses):
+            raise PreventUpdate
+
+        selected_response = corr_param_resp["response"]
+        _plots = []
+        _obs_plots = []
+
+        for ensemble_id, data in ensembles.items():
+            ensemble = load_ensemble(parent, ensemble_id)
+            response = ensemble.responses[selected_response]
+            x_axis = response.axis
+            if str(x_axis[0]).isnumeric():
+                style = deepcopy(assets.ERTSTYLE["response-plot"]["response-index"])
+            else:
+                style = deepcopy(assets.ERTSTYLE["response-plot"]["response"])
+            data_df = response.data_df()
+
+            style["marker"]["color"] = data["color"]
+            _plots += [
+                PlotModel(
+                    x_axis=x_axis,
+                    y_axis=data_df[x_val],
+                    text="Mean",
+                    name=f"Mean {repr(ensemble)}",
+                    **style,
+                )
+                for x_val in data_df
+            ]
+
+            for obs in response.observations:
+                _obs_plots += _get_observation_plots(obs.data_df(), x_axis)
+
+        fig = go.Figure()
+        for plot in _plots:
+            fig.add_trace(plot.repr)
+
+        _layout = assets.ERTSTYLE["figure"]["layout"].copy()
+        _layout.update(dict(showlegend=False))
+        fig.update_layout(_layout)
+
+        x_index = corr_xindex.get(selected_response, 0)
+        fig.add_shape(
+            type="line",
+            x0=x_axis[x_index],
+            y0=0,
+            x1=x_axis[x_index],
+            y1=1,
+            yref="paper",
+            line=dict(color="rgb(30, 30, 30)", dash="dash", width=3),
+        )
+        # draw observations on top
+        for plot in _obs_plots:
+            fig.add_trace(plot.repr)
+
+        fig.update_layout(clickmode="event+select")
+        return fig
+
+    @app.callback(
+        [
+            Output(
+                {
+                    "id": parent.uuid("response-scatterplot"),
+                    "type": parent.uuid("graph"),
+                },
+                "figure",
+            ),
+            Output(parent.uuid("response-info-text"), "children"),
+        ],
+        [
+            Input(parent.uuid("correlation-store-xindex"), "data"),
+            Input(parent.uuid("correlation-store-selection"), "data"),
+        ],
+        [
+            State(parent.uuid("parameter-selection-store-param"), "data"),
+            State(parent.uuid("parameter-selection-store-resp"), "data"),
+            State(parent.uuid("ensemble-selection-store"), "data"),
+        ],
+    )
+    def update_response_parameter_scatterplot(
+        corr_xindex,
+        corr_param_resp,
+        parameters,
+        responses,
+        ensembles,
+    ):
+
+        if not (
+            parameters
+            and ensembles
+            and responses
+            and corr_param_resp["parameter"] in parameters
+            and corr_param_resp["response"] in responses
+        ):
+            raise PreventUpdate
+
+        selected_parameter = corr_param_resp["parameter"]
+        selected_response = corr_param_resp["response"]
+        _plots = []
+        _resp_plots = {}
+        _param_plots = {}
+        _colors = {}
+
+        for ensemble_id, data in ensembles.items():
+            ensemble = load_ensemble(parent, ensemble_id)
+            y_data = ensemble.parameters[selected_parameter].data_df()
+            response = ensemble.responses[selected_response]
+            x_index = corr_xindex.get(selected_response, 0)
+            x_data = response.data_df().iloc[x_index]
+            style = deepcopy(assets.ERTSTYLE["response-plot"]["response-index"])
+            style["marker"]["color"] = data["color"]
+            _colors[str(ensemble)] = data["color"]
+            _plots += [
+                PlotModel(
+                    x_axis=x_data.values.flatten(),
+                    y_axis=y_data.values.flatten(),
+                    text="Mean",
+                    name=f"{repr(ensemble)}: {selected_response}x{selected_parameter}@{response.axis[x_index]}",
+                    **style,
+                )
+            ]
+            _resp_plots[str(ensemble)] = x_data.values.flatten()
+            _param_plots[str(ensemble)] = y_data.values.flatten()
+
+        fig = make_subplots(
+            rows=4,
+            cols=2,
+            specs=[
+                [{"colspan": 2, "rowspan": 3}, None],
+                [None, None],
+                [None, None],
+                [{"rowspan": 1}, {"rowspan": 1}],
+            ],
+        )
+        for plot in _plots:
+            fig.add_trace(plot.repr, 1, 1)
+
+        for key in _param_plots:
+            fig.add_trace(
+                {
+                    "type": "histogram",
+                    "x": _param_plots[key],
+                    "showlegend": False,
+                    "marker_color": _colors[key],
+                },
+                4,
+                1,
+            )
+        for key in _resp_plots:
+            fig.add_trace(
+                {
+                    "type": "histogram",
+                    "x": _resp_plots[key],
+                    "showlegend": False,
+                    "marker_color": _colors[key],
+                },
+                4,
+                2,
+            )
+        fig.update_layout(assets.ERTSTYLE["figure"]["layout"])
+        fig.update_layout(showlegend=False)
+        res_text = ""
+        for response in responses:
+            x_axis = ensemble.responses[response].axis
+            x_value = x_axis[corr_xindex.get(response, 0)]
+            if response == selected_response:
+                res_text += f"**{response} @ {x_value}**, "
+            else:
+                res_text += f"{response} @ {x_value}, "
+        res_text = [dcc.Markdown(res_text)]
+        res_text += [dcc.Markdown(f"parameter: **{corr_param_resp['parameter']}**")]
+        return fig, html.Div(res_text)
+
+    @app.callback(
+        Output(parent.uuid("correlation-store-xindex"), "data"),
+        [
+            Input(
+                {"id": parent.uuid("response-overview"), "type": parent.uuid("graph")},
+                "clickData",
+            ),
+            Input(parent.uuid("parameter-selection-store-resp"), "data"),
+        ],
+        [
+            State(parent.uuid("correlation-store-xindex"), "data"),
+            State(parent.uuid("correlation-store-selection"), "data"),
+        ],
+    )
+    def update_corr_index(click_data, responses, corr_xindex, corr_param_resp):
+        if not responses:
+            raise PreventUpdate
+
+        ctx = dash.callback_context
+        triggered_id = ctx.triggered[0]["prop_id"].split(".")[0]
+
+        if triggered_id == parent.uuid("parameter-selection-store-resp"):
+            return {response: corr_xindex.get(response, 0) for response in responses}
+        if click_data:
+            corr_xindex[corr_param_resp["response"]] = click_data["points"][0][
+                "pointIndex"
+            ]
+        return corr_xindex
+
+    @app.callback(
+        Output(parent.uuid("correlation-store-selection"), "data"),
+        [
+            Input(
+                {
+                    "id": parent.uuid("response-heatmap"),
+                    "type": parent.uuid("graph"),
+                },
+                "clickData",
+            ),
+            Input(parent.uuid("parameter-selection-store-resp"), "data"),
+            Input(parent.uuid("parameter-selection-store-param"), "data"),
+        ],
+        [
+            State(parent.uuid("correlation-store-selection"), "data"),
+        ],
+    )
+    def update_corr_param_resp(click_data, responses, parameters, corr_param_resp):
+        ctx = dash.callback_context
+        triggered_id = ctx.triggered[0]["prop_id"].split(".")[0]
+        if triggered_id == parent.uuid("parameter-selection-store-resp") and responses:
+            corr_param_resp["response"] = (
+                corr_param_resp["response"]
+                if corr_param_resp["response"] in responses
+                else responses[0]
+            )
+        elif (
+            triggered_id == parent.uuid("parameter-selection-store-param")
+            and parameters
+        ):
+            corr_param_resp["parameter"] = (
+                corr_param_resp["parameter"]
+                if corr_param_resp["parameter"] in parameters
+                else parameters[0]
+            )
+        elif click_data:
+            corr_param_resp["parameter"] = click_data["points"][0]["y"]
+            corr_param_resp["response"] = click_data["points"][0]["x"]
+        return corr_param_resp

--- a/ertviz/models/__init__.py
+++ b/ertviz/models/__init__.py
@@ -35,6 +35,7 @@ from .plot_model import (
     MultiHistogramPlotModel,
     BoxPlotModel,
     ParallelCoordinatesPlotModel,
+    BarChartPlotModel,
 )
 from .parameter_model import PriorModel, ParametersModel
 from .ensemble_model import EnsembleModel

--- a/ertviz/models/ensemble_model.py
+++ b/ertviz/models/ensemble_model.py
@@ -102,4 +102,4 @@ class EnsembleModel:
         return f"{self._time_created}, {self._name}"
 
     def __repr__(self):
-        return f"{self._name}"
+        return f"{self.id}, {self._name}"

--- a/ertviz/models/plot_model.py
+++ b/ertviz/models/plot_model.py
@@ -124,6 +124,49 @@ class BoxPlotModel:
             return self._name
 
 
+class BarChartPlotModel:
+    def __init__(self, data_df_dict, colors):
+        self._data_df_dict = data_df_dict
+        self._colors = colors
+        self.selection = []
+
+    @property
+    def plot_ids(self):
+        return {plot_idx: ens_name for plot_idx, ens_name in enumerate(self.data)}
+
+    @property
+    def data(self):
+        return self._data_df_dict
+
+    @property
+    def repr(self):
+        fig = go.Figure()
+        for ens_name in self.data:
+            fig.add_trace(
+                go.Bar(
+                    x=self.data[ens_name].values,
+                    y=self.data[ens_name].index,
+                    orientation="h",
+                    name=ens_name,
+                    marker=dict(
+                        color=self._colors[ens_name],
+                    ),
+                ),
+            )
+        _layout = assets.ERTSTYLE["figure"]["layout"].copy()
+        _layout.update(
+            {
+                "showlegend": False,
+                "yaxis": {
+                    "showticklabels": True,
+                },
+                "font": {"size": 10},
+            }
+        )
+        fig.update_layout(_layout)
+        return fig
+
+
 class PlotModel:
     def __init__(self, **kwargs):
         self._x_axis = kwargs["x_axis"]

--- a/ertviz/plugins/__init__.py
+++ b/ertviz/plugins/__init__.py
@@ -2,3 +2,4 @@ from ._ensemble_overview import EnsembleOverview
 from ._response_comparison import ResponseComparison
 from ._observation_analyzer import ObservationAnalyzer
 from ._parameter_comparison import ParameterComparison
+from ._response_correlation import ResponseCorrelation

--- a/ertviz/plugins/_response_correlation.py
+++ b/ertviz/plugins/_response_correlation.py
@@ -1,0 +1,115 @@
+import dash_html_components as html
+import dash_core_components as dcc
+import dash_bootstrap_components as dbc
+from webviz_config import WebvizPluginABC
+from ertviz.views import (
+    ensemble_selector_view,
+    correlation_view,
+    parameter_selector_view,
+)
+from ertviz.controllers import (
+    ensemble_selector_controller,
+    response_correlation_controller,
+    parameter_selector_controller,
+)
+
+
+class ResponseCorrelation(WebvizPluginABC):
+    def __init__(self, app, project_identifier: str):
+        super().__init__()
+        self.project_identifier = project_identifier
+        self.ensembles = {}
+        self.set_callbacks(app)
+
+    @property
+    def layout(self):
+        return html.Div(
+            [
+                dcc.Store(
+                    id=self.uuid("correlation-store-xindex"),
+                    data={},
+                ),
+                dcc.Store(
+                    id=self.uuid("correlation-store-selection"),
+                    data={"parameter": "x", "response": "y"},
+                ),
+                html.Div(
+                    id=self.uuid("ensemble-content"),
+                    children=ensemble_selector_view(parent=self),
+                ),
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Label("Responses", className="ert-label"),
+                                parameter_selector_view(
+                                    self, data_type="response", suffix="resp"
+                                ),
+                            ],
+                            width=6,
+                        ),
+                        dbc.Col(
+                            [
+                                html.Label("Parameters", className="ert-label"),
+                                parameter_selector_view(
+                                    self, data_type="parameter", suffix="param"
+                                ),
+                            ],
+                            width=6,
+                        ),
+                    ],
+                ),
+                dcc.RadioItems(
+                    id=self.uuid("correlation-metric"),
+                    options=[
+                        {"label": "spearman", "value": "spearman"},
+                        {"label": "pearson", "value": "pearson"},
+                    ],
+                    value="pearson",
+                    labelStyle={"display": "inline-block"},
+                ),
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            correlation_view(
+                                parent=self,
+                                id_view=self.uuid("response-overview"),
+                            ),
+                            width=3,
+                        ),
+                        dbc.Col(
+                            correlation_view(
+                                parent=self,
+                                id_view=self.uuid("response-scatterplot"),
+                            ),
+                            width=3,
+                        ),
+                        dbc.Col(
+                            correlation_view(
+                                parent=self,
+                                id_view=self.uuid("response-correlation"),
+                            ),
+                            width=3,
+                        ),
+                        dbc.Col(
+                            correlation_view(
+                                parent=self,
+                                id_view=self.uuid("response-heatmap"),
+                            ),
+                            width=3,
+                        ),
+                    ]
+                ),
+                html.Div(
+                    id=self.uuid("response-info-text"),
+                    className="ert-label",
+                    children=[dcc.Markdown("INFO")],
+                ),
+            ]
+        )
+
+    def set_callbacks(self, app):
+        ensemble_selector_controller(self, app)
+        response_correlation_controller(self, app)
+        parameter_selector_controller(self, app, suffix="param", union_keys=False)
+        parameter_selector_controller(self, app, suffix="resp")

--- a/ertviz/views/__init__.py
+++ b/ertviz/views/__init__.py
@@ -5,3 +5,4 @@ from .plot_view import plot_view_body, plot_view_header, plot_view_menu
 from .misfit_view import response_obs_view
 from .parallel_coordinates_view import parallel_coordinates_view
 from .selector_view import parameter_selector_view
+from .correlation_view import correlation_view

--- a/ertviz/views/correlation_view.py
+++ b/ertviz/views/correlation_view.py
@@ -1,0 +1,18 @@
+import dash_html_components as html
+import dash_core_components as dcc
+
+
+def correlation_view(parent, id_view):
+    return html.Div(
+        className="ert-view-container",
+        children=[
+            dcc.Graph(
+                id={
+                    "id": id_view,
+                    "type": parent.uuid("graph"),
+                },
+                className="ert-view-cell",
+                config={"responsive": True},
+            )
+        ],
+    )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
             "ResponseComparison = ertviz.plugins:ResponseComparison",
             "ObservationAnalyzer = ertviz.plugins:ObservationAnalyzer",
             "ParameterComparison = ertviz.plugins:ParameterComparison",
+            "ResponseCorrelation = ertviz.plugins:ResponseCorrelation",
         ],
         "ert": [
             "ertviz = ertviz.ert_hooks",

--- a/tests/plots/test_controller.py
+++ b/tests/plots/test_controller.py
@@ -16,6 +16,7 @@ from ertviz.models import (
     MultiHistogramPlotModel,
     BoxPlotModel,
     ParallelCoordinatesPlotModel,
+    BarChartPlotModel,
 )
 import ertviz.assets as assets
 
@@ -218,3 +219,35 @@ def test_boxplot_representation():
     np.testing.assert_equal(plot.y.flatten(), data)
     assert plot.boxpoints == "all"
     assert plot.name == "Boxplot@Location5"
+
+
+def test_barchart_representation():
+    data_dict = {}
+    colors_dict = {}
+
+    ensemble_names = ["default", "update_1", "update_2"]
+    colors = assets.ERTSTYLE["ensemble-selector"]["color_wheel"]
+    param_num = 5
+    for idx, (ensemble_name, color) in enumerate(
+        zip(ensemble_names, colors[: len(ensemble_names)])
+    ):
+        key = f"{idx}, {ensemble_name}"
+        data = np.random.rand(param_num)
+        data_df = pd.DataFrame(
+            data=data, index=[f"PARAM_{i}" for i in range(param_num)]
+        )
+        data_dict[key] = data_df
+        colors_dict[key] = color
+
+    plot = BarChartPlotModel(data_dict, colors_dict)
+    plot = plot.repr
+
+    for idx, ensemble_name in enumerate(ensemble_names):
+        key = f"{idx}, {ensemble_name}"
+        assert plot.data[idx].name == key
+        np.testing.assert_equal(
+            plot.data[idx].y, [f"PARAM_{i}" for i in range(param_num)]
+        )
+        assert plot.data[idx].orientation == "h"
+        assert plot.data[idx].x.shape == (param_num, 1)
+        assert plot.data[idx].marker.color == colors[idx]

--- a/tests/views/test_response_correlation.py
+++ b/tests/views/test_response_correlation.py
@@ -1,0 +1,42 @@
+import dash
+from ertviz.plugins._response_correlation import ResponseCorrelation
+
+
+def test_response_correlation_view(
+    mock_data,
+    dash_duo,
+):
+    app = dash.Dash(__name__)
+
+    plugin = ResponseCorrelation(app, project_identifier=None)
+    layout = plugin.layout
+    app.layout = layout
+    dash_duo.start_server(app)
+    windowsize = (630, 1200)
+    dash_duo.driver.set_window_size(*windowsize)
+    ensemble_elements = dash_duo.find_element(".ert-ensemble-selector-large")
+
+    # The position is hard coded coordinates normalized to the extent of the
+    # ensemble-selector
+    x, y = (0.5, 0.15)
+    dash_duo.click_at_coord_fractions(ensemble_elements, x, y)
+    resp_select = dash_duo.find_element(
+        "#" + plugin.uuid("parameter-selector-multi-resp")
+    )
+
+    x, y = (0.5, 0.1)
+    dash_duo.click_at_coord_fractions(resp_select, x, y)
+
+    param_select = dash_duo.find_element(
+        "#" + plugin.uuid("parameter-selector-multi-param")
+    )
+    param_select.click()
+
+    x, y = (0.5, 0.1)
+    # double click's for the sake if other parameter comes first
+    dash_duo.click_at_coord_fractions(param_select, x, y)
+
+    response_views = dash_duo.find_elements(".ert-view-cell")
+    assert len(response_views) == 4
+
+    assert dash_duo.get_logs() == [], "browser console should contain no error"


### PR DESCRIPTION
Resolves #84

Currently supporting `Person` and `Spearman` correlation.

TODO:

- [x] tests for the new `BarChartPlotModel` and integration tests
- [x] Support for selection between `Spearman` correlation and `Pearson`
- [x] Allow for selection of `x_values` on `time-axis` or on `index-axis` and perform correlation only for the corresponding x
- [x] Discussion on correlating responses too (we don't implement it now)
- [x] Allow for parameter selection from `BarChartPlotModel`

Todos from meeting with Eivind:
- [x] we can treat each response data as `index` series and provide selection of `indices` for which we compute / show correlation data
- [x] add graph showing the selected response
- [x] add scatterplot with 2 linked histograms (x and y axis) showing the current selected response / parameter from the correlation plot
- [x] put correlation of parameters (heatmaps) into `Parameter comparison view` (Made a stand-alone issue: #130 )
- [x] response plot should display all realizations
- [x] histogram should be smaller

From meeting 03.03.2021
- [x] introduce concepts: `selected` response and `selected` x_value for that response
- [x] do correlation for the above selections
- [x] display both heatmap and tornado side by side