### PR TITLE
Add help tour_steps for correlation view plugin

### DIFF
--- a/ertviz/plugins/_response_correlation.py
+++ b/ertviz/plugins/_response_correlation.py
@@ -22,6 +22,57 @@ class ResponseCorrelation(WebvizPluginABC):
         self.set_callbacks(app)
 
     @property
+    def tour_steps(self):
+        steps = [
+            {
+                "id": self.uuid("correlation-metric"),
+                "content": (
+                    "Which metric to use, all views are automatically updated. "
+                ),
+            },
+            {
+                "id": self.uuid("response-overview"),
+                "content": (
+                    "Visualization of the currently selected response "
+                    "where by clicking we can select a new index / timestep for correlation analysis."
+                ),
+            },
+            {
+                "id": self.uuid("response-scatterplot"),
+                "content": (
+                    "Scatterplot visualization of function values between currently selected "
+                    "response and currently selected parameter. "
+                    "It is accompanied by distribution plots for both selections. "
+                ),
+            },
+            {
+                "id": self.uuid("response-heatmap"),
+                "content": (
+                    "Heatmap based representation of correlation (-1, 1) among all selected responses "
+                    "and parameters, for currently active ensembles in column-wise fashion."
+                    "One can select a currently active response and parameter "
+                    "by clicking directly on a heatmap. "
+                ),
+            },
+            {
+                "id": self.uuid("response-correlation"),
+                "content": (
+                    "Correlation BarChart for the single selected response (from heatmap) "
+                    "and parameters in a descending order. "
+                ),
+            },
+            {
+                "id": self.uuid("response-info-text"),
+                "content": (
+                    "All reponses with selected their x_index / timestep; "
+                    "the currently active response and parameter are made bold. "
+                ),
+            },
+        ]
+
+        return steps
+
+    @property
     def layout(self):
         return html.Div(
             [

--- a/ertviz/views/correlation_view.py
+++ b/ertviz/views/correlation_view.py
@@ -4,6 +4,7 @@ import dash_core_components as dcc
 
 def correlation_view(parent, id_view):
     return html.Div(
+        id=id_view,
         className="ert-view-container",
         children=[
             dcc.Graph(


### PR DESCRIPTION
Resolves #134

This exploits the `tour_steps` property of the plugin. 
- [x] make it jump across views when doing the tour