### PR TITLE
Get record data for active realizations

### DIFF
--- a/tests/data/snake_oil_data.py
+++ b/tests/data/snake_oil_data.py
@@ -68,6 +68,7 @@ ensembles_response = {
                 "id": 1,
                 "timeCreated": "2020-04-29T09:36:26",
                 "size": 1,
+                "activeRealizations": [0],
                 "userdata": '{"name": "default"}',
             }
         }
@@ -91,6 +92,7 @@ ensembles_response = {
                 "id": 2,
                 "timeCreated": "2020-04-29T10:36:26",
                 "size": 1,
+                "activeRealizations": [0],
                 "userdata": '{"name": "default_smoother_update"}',
             }
         }
@@ -111,6 +113,7 @@ ensembles_response = {
                 "id": 3,
                 "timeCreated": "2020-04-29T10:57:47",
                 "size": 1,
+                "activeRealizations": [0],
                 "userdata": '{"name": "default3"}',
             }
         }
@@ -138,6 +141,7 @@ ensembles_response = {
                 "id": 4,
                 "timeCreated": "2020-04-29T10:59:37",
                 "size": 1,
+                "activeRealizations": [0],
                 "userdata": '{"name": "default4"}',
             }
         }

--- a/tests/models/test_response_model.py
+++ b/tests/models/test_response_model.py
@@ -4,10 +4,11 @@ from webviz_ert.models import Response
 def test_response_model(mock_data):
     resp_model = Response(
         "SNAKE_OIL_GPR_DIFF",
-        ensemble_id=1,
+        ensemble_id="1",
         response_id="SNAKE_OIL_GPR_DIFF",
         project_id="",
         ensemble_size=1,
+        active_realizations=[0],
     )
     assert resp_model.name == "SNAKE_OIL_GPR_DIFF"
     assert len(resp_model.data.columns) == 1

--- a/webviz_ert/data_loader/__init__.py
+++ b/webviz_ert/data_loader/__init__.py
@@ -67,6 +67,7 @@ query ($id: ID!) {
   ensemble(id: $id) {
     id
     size
+    activeRealizations
     timeCreated
     children {
       ensembleResult{
@@ -207,10 +208,10 @@ class DataLoader:
         return df
 
     def get_ensemble_record_data(
-        self, ensemble_id: str, record_name: str, ensemble_size: int
+        self, ensemble_id: str, record_name: str, active_realizations: List[int]
     ) -> pd.DataFrame:
         dfs = []
-        for rel_idx in range(ensemble_size):
+        for rel_idx in active_realizations:
             try:
                 resp = self._get(
                     url=f"ensembles/{ensemble_id}/records/{record_name}",

--- a/webviz_ert/models/ensemble_model.py
+++ b/webviz_ert/models/ensemble_model.py
@@ -51,6 +51,7 @@ class EnsembleModel:
         self._children = self._schema["children"]
         self._parent = self._schema["parent"]
         self._size = self._schema["size"]
+        self._active_realizations = self._schema["activeRealizations"]
         self._time_created = self._schema["timeCreated"]
         self.responses = {
             resp_name: Response(
@@ -59,6 +60,7 @@ class EnsembleModel:
                 ensemble_id=ensemble_id,
                 project_id=project_id,
                 ensemble_size=self._size,
+                active_realizations=self._active_realizations,
             )
             for resp_name, resp_schema in self._data_loader.get_ensemble_responses(
                 ensemble_id

--- a/webviz_ert/models/response.py
+++ b/webviz_ert/models/response.py
@@ -14,6 +14,7 @@ class Response:
         ensemble_id: str,
         project_id: str,
         ensemble_size: int,
+        active_realizations: List[int],
     ):
         self._data_loader: DataLoader = get_data_loader(project_id)
         self._document: Optional[Mapping[str, Any]] = None
@@ -25,6 +26,7 @@ class Response:
         self._univariate_misfits_df: Optional[pd.DataFrame] = None
         self._summary_misfits_df: Optional[pd.DataFrame] = None
         self._ensemble_size: int = ensemble_size
+        self._active_realizations: List[int] = active_realizations
 
     @property
     def ensemble_id(self) -> str:
@@ -38,7 +40,7 @@ class Response:
     def data(self) -> pd.DataFrame:
         if self._data is None:
             self._data = self._data_loader.get_ensemble_record_data(
-                self._ensemble_id, self.name, self._ensemble_size
+                self._ensemble_id, self.name, self._active_realizations
             )
         return self._data
 


### PR DESCRIPTION
**Issue**
Related to: https://github.com/equinor/ert-storage/issues/164


Do not assume that all realizations are active and that we will find record data for all the realization indices.
Only get record data for active realizations if given