### PR TITLE
Pin selenium version to 3.141.0

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ pylint
 black
 scipy
 dash[testing]
-selenium
+selenium==3.141.0
 types-requests
 types-pkg_resources
 types-PyYAML


### PR DESCRIPTION
Due to the fact newer selenium versions are not compatible with
the chromium drivers currently installed on our nodes - we need
to pin the selenium version until that is fixed.