### PR TITLE
Move minimization window to right

### DIFF
--- a/webviz_ert/assets/ert-style.css
+++ b/webviz_ert/assets/ert-style.css
@@ -25,7 +25,7 @@
     position: fixed;
     bottom: 30px;
     z-index: 999;
-    left: 30px;
+    right: 30px;
 }
 .ert-ensemble-selector-container-large {
     display: flex;


### PR DESCRIPTION
Resolves #181

Because the webviz left sidebar can be collapsed now results in either a poorly positioned minimized ensemble view window or a partially hidden minimized ensemble view window. 

An acceptable solution was to move the minimized ensemble view window to the bottom right of the screen. The result looks similar the following example:

![Screenshot from 2021-10-26 12-52-26](https://user-images.githubusercontent.com/4508053/138856815-0033879f-5e53-4eeb-9bd3-baf3cb8eabea.png)
 
