### PR TITLE
Account for ert and ert3 discrepancy when uploading parameter data to storage

### DIFF
--- a/tests/data/snake_oil_data.py
+++ b/tests/data/snake_oil_data.py
@@ -267,3 +267,69 @@ ensembles_response[
         index=["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
     ).transpose()
 )
+
+ensembles_response.update(
+    {
+        "http://127.0.0.1:5000/ensembles/42": {
+            "data": {
+                "ensemble": {
+                    "children": [],
+                    "experiment": {"id": "exp1_id"},
+                    "parent": None,
+                    "id": 1,
+                    "timeCreated": "2020-04-29T09:36:26",
+                    "size": 1,
+                    "activeRealizations": [0],
+                    "userdata": '{"name": "default"}',
+                }
+            }
+        },
+        "http://127.0.0.1:5000/ensembles/42/parameters": [
+            "test_parameter_1",
+            "test_parameter_2",
+        ],
+        "http://127.0.0.1:5000/ensembles/42/responses": {
+            "test_resposne": {
+                "name": "name_test_response",
+                "id": "test_response_id_1",
+            },
+        },
+        "http://127.0.0.1:5000/ensembles/42/records/test_parameter_1/labels": [],
+        "http://127.0.0.1:5000/ensembles/42/records/test_parameter_2/labels": [
+            "a",
+            "b",
+        ],
+        "http://127.0.0.1:5000/ensembles/42/records/test_parameter_2/labels": [
+            "a",
+            "b",
+        ],
+    }
+)
+
+ensembles_response[
+    "" "http://127.0.0.1:5000/ensembles/42/records/test_parameter_1?"
+] = to_parquet_helper(
+    pd.DataFrame(
+        [0.1, 1.1, 2.1],
+        columns=["0"],
+        index=["0", "1", "2"],
+    ).transpose()
+)
+ensembles_response[
+    "http://127.0.0.1:5000/ensembles/42/records/test_parameter_2?label=a"
+] = to_parquet_helper(
+    pd.DataFrame(
+        [0.01, 1.01, 2.01],
+        columns=["a"],
+        index=["0", "1", "2"],
+    ).transpose()
+)
+ensembles_response[
+    "http://127.0.0.1:5000/ensembles/42/records/test_parameter_2?label=b"
+] = to_parquet_helper(
+    pd.DataFrame(
+        [0.02, 1.02, 2.02],
+        columns=["b"],
+        index=["0", "1", "2"],
+    ).transpose()
+)

--- a/tests/data/snake_oil_data.py
+++ b/tests/data/snake_oil_data.py
@@ -156,6 +156,8 @@ ensembles_response = {
             "id": "FOPR",
         },
     },
+    "http://127.0.0.1:5000/ensembles/1/records/OP1_DIVERGENCE_SCALE/labels": [],
+    "http://127.0.0.1:5000/ensembles/1/records/BPR_138_PERSISTENCE/labels": [],
     "http://127.0.0.1:5000/ensembles/1/records/SNAKE_OIL_GPR_DIFF/observations?realization_index=0": [],
     "http://127.0.0.1:5000/ensembles/3/records/SNAKE_OIL_GPR_DIFF?realization_index=0": pd.DataFrame(
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
@@ -227,6 +229,16 @@ def to_parquet_helper(dataframe: pd.DataFrame) -> bytes:
 
 ensembles_response[
     "http://127.0.0.1:5000/ensembles/1/records/SNAKE_OIL_GPR_DIFF?realization_index=0"
+] = to_parquet_helper(
+    pd.DataFrame(
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        columns=["0"],
+        index=["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    ).transpose()
+)
+
+ensembles_response[
+    "http://127.0.0.1:5000/ensembles/1/records/SNAKE_OIL_GPR_DIFF"
 ] = to_parquet_helper(
     pd.DataFrame(
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],

--- a/tests/models/test_ensemble_model.py
+++ b/tests/models/test_ensemble_model.py
@@ -7,3 +7,44 @@ def test_ensemble_model(mock_data):
     assert ens_model.children[0]._name == "default_smoother_update"
     assert ens_model._name == "default"
     assert len(ens_model.responses) == 1
+
+
+def test_ensemble_model_labled_parameters(mock_data):
+    ens_id = 42
+    ens_model = EnsembleModel(ensemble_id=ens_id, project_id=None)
+    assert ens_model._name == "default"
+    assert len(ens_model.parameters) == 3
+    for param_name, parameter in ens_model.parameters.items():
+        name, label = (
+            param_name.split("::", maxsplit=1)
+            if "::" in param_name
+            else [param_name, None]
+        )
+        expected_lables = ens_model._data_loader.get_record_labels(ens_id, name)
+        if label is not None:
+            assert label in expected_lables
+
+
+def test_ensemble_model_parameter_data(mock_data):
+    ens_id = 42
+    ens_model = EnsembleModel(ensemble_id=ens_id, project_id=None)
+    parameters = ens_model.parameters
+    assert len(parameters) == 3
+
+    # Parameter no lables:
+    expected_lables = ens_model._data_loader.get_record_labels(
+        ens_id, "test_parameter_1"
+    )
+    assert expected_lables == []
+    data = parameters["test_parameter_1"].data_df().values
+    assert data.flatten().tolist() == [0.1, 1.1, 2.1]
+
+    # Parameter with lables:
+    expected_lables = ens_model._data_loader.get_record_labels(
+        ens_id, "test_parameter_2"
+    )
+    assert expected_lables == ["a", "b"]
+    data = parameters["test_parameter_2::a"].data_df()["a"].values.tolist()
+    assert data == [0.01, 1.01, 2.01]
+    data = parameters["test_parameter_2::b"].data_df()["b"].values.tolist()
+    assert data == [0.02, 1.02, 2.02]

--- a/webviz_ert/models/parameter_model.py
+++ b/webviz_ert/models/parameter_model.py
@@ -30,10 +30,10 @@ class ParametersModel:
     def data_df(self) -> pd.DataFrame:
         if self._data_df.empty:
             _data_df = self._data_loader.get_ensemble_parameter_data(
-                ensemble_id=self._ensemble_id, parameter_name=self.key
+                ensemble_id=self._ensemble_id,
+                parameter_name=self.key,
             )
             if _data_df is not None:
-                _data_df = _data_df.transpose()
                 _data_df.index.name = self.key
                 self._data_df = _data_df
         return self._data_df

--- a/webviz_ert/models/response.py
+++ b/webviz_ert/models/response.py
@@ -40,7 +40,7 @@ class Response:
     def data(self) -> pd.DataFrame:
         if self._data is None:
             self._data = self._data_loader.get_ensemble_record_data(
-                self._ensemble_id, self.name, self._active_realizations
+                self._ensemble_id, self.name
             )
         return self._data
 


### PR DESCRIPTION
**Issue**
Resolves: #191 

It seems parameters are handled differently for ert3 and ert at the moment:

* **Ert3**: uploads a record for each realisation index.
* **Ert**: uploads only one global record for each parameter. 

**Approach**

For a given parameter (i.e. coefficients) try to retrieve a global record (assuming the user has run ERT) if this fails for the same parameter try to retrieve a record for a realization index in the list of active realization of the run example.   