### PR TITLE
Handle labels in the parameter list from updated API.

### DIFF
--- a/tests/data/snake_oil_data.py
+++ b/tests/data/snake_oil_data.py
@@ -74,8 +74,8 @@ ensembles_response = {
         }
     },
     "http://127.0.0.1:5000/ensembles/1/parameters": [
-        "BPR_138_PERSISTENCE",
-        "OP1_DIVERGENCE_SCALE",
+        {"name": "BPR_138_PERSISTENCE", "labels": []},
+        {"name": "OP1_DIVERGENCE_SCALE", "labels": []},
     ],
     "http://127.0.0.1:5000/ensembles/1/responses": {
         "SNAKE_OIL_GPR_DIFF": {

--- a/tests/data/snake_oil_data.py
+++ b/tests/data/snake_oil_data.py
@@ -285,8 +285,8 @@ ensembles_response.update(
             }
         },
         "http://127.0.0.1:5000/ensembles/42/parameters": [
-            "test_parameter_1",
-            "test_parameter_2",
+            {"name": "test_parameter_1", "labels": []},
+            {"name": "test_parameter_2", "labels": ["a", "b"]},
         ],
         "http://127.0.0.1:5000/ensembles/42/responses": {
             "test_resposne": {

--- a/webviz_ert/models/ensemble_model.py
+++ b/webviz_ert/models/ensemble_model.py
@@ -100,8 +100,9 @@ class EnsembleModel:
     ) -> Optional[Mapping[str, ParametersModel]]:
         if not self._parameters:
             parameter_names = []
-            for param_name in self._data_loader.get_ensemble_parameters(self._id):
-                labels = self._data_loader.get_record_labels(self._id, param_name)
+            for params in self._data_loader.get_ensemble_parameters(self._id):
+                labels = params["labels"]
+                param_name = params["name"]
                 if len(labels) > 0:
                     for label in labels:
                         parameter_names.append(f"{param_name}::{label}")


### PR DESCRIPTION
**Issue**
Resolves #211


**Approach**
Match updates in dark storage and ert storage that returns labels as part of parameters when querying the `parameters` endpoint