### PR TITLE
Remove search from some dropdowns

### DIFF
--- a/tests/views/test_parameter_selector.py
+++ b/tests/views/test_parameter_selector.py
@@ -127,7 +127,7 @@ def test_search_input_return_functionality(
     dash_duo.clear_input(parameter_deactivator)
 
     dash_duo.wait_for_contains_text(
-        "#" + plugin.uuid("parameter-deactivator-params"), "Select...", timeout=4
+        "#" + plugin.uuid("parameter-deactivator-params"), "", timeout=4
     )
 
     parameter_selector_input = dash_duo.find_element(
@@ -135,7 +135,7 @@ def test_search_input_return_functionality(
     )
     parameter_selector_input.send_keys(Keys.ENTER)
     dash_duo.wait_for_contains_text(
-        "#" + plugin.uuid("parameter-deactivator-params"), "Select...", timeout=4
+        "#" + plugin.uuid("parameter-deactivator-params"), "", timeout=4
     )
 
     parameter_selector_input.send_keys("OP1")
@@ -151,7 +151,7 @@ def test_search_input_return_functionality(
     parameter_selector_input.send_keys(Keys.ENTER)
 
     dash_duo.wait_for_contains_text(
-        "#" + plugin.uuid("parameter-deactivator-params"), "Select...", timeout=4
+        "#" + plugin.uuid("parameter-deactivator-params"), "", timeout=4
     )
     dash_duo.click_at_coord_fractions(parameter_selector_container, 0.1, 0.05)
     dash_duo.wait_for_contains_text(

--- a/webviz_ert/views/ensemble_selector_view.py
+++ b/webviz_ert/views/ensemble_selector_view.py
@@ -31,6 +31,8 @@ def ensemble_selector_list(parent: WebvizPluginABC) -> List[Component]:
             multi=True,
             options=[],
             persistence=True,
+            searchable=False,
+            placeholder="",
             persistence_type="session",
         ),
         dcc.Store(id=parent.uuid("ensemble-selection-store"), storage_type="session"),

--- a/webviz_ert/views/selector_view.py
+++ b/webviz_ert/views/selector_view.py
@@ -53,6 +53,8 @@ def parameter_selector_view(
             dcc.Dropdown(
                 id=parent.uuid(f"parameter-deactivator-{suffix}"),
                 multi=True,
+                searchable=False,
+                placeholder="",
                 persistence="session",
             ),
             dcc.Store(


### PR DESCRIPTION
**Issue**
Resolves #235 

Removed search functionality from dropdowns for ensemble and parameters (same as responses). 
Removed "Select ..." text in the box which is misleading. 

