### PR TITLE
Update chromeiumdriver to support currently installed chrome 99

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -20,7 +20,7 @@ start_tests () {
 start_integration_test () {
     
     echo "Downloading chromedriver ..."
-    wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/90.0.4430.24/chromedriver_linux64.zip
+    wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/99.0.4844.51/chromedriver_linux64.zip
     unzip chromedriver.zip chromedriver -d ../test-kenv/root/bin
 
     pip install pytest selenium dash[testing]


### PR DESCRIPTION
**Issue**
Chrome is updated on our jenkins-nodes to 99 and the chromeiumdriver currently installed does not support it. 


**Approach**
Update the chromeiumdriver to correct version


## Pre review checklist

- [x] Added appropriate labels
