### PR TITLE
Fix overlapping parameter plot headers

### DIFF
--- a/webviz_ert/assets/ert-style.css
+++ b/webviz_ert/assets/ert-style.css
@@ -13,3 +13,21 @@
 .ert-parameter-label-checkbox {
     display: block;
 }
+.ert-input-number {
+    width: 65px;
+}
+.ert-parameter-view-caption {
+    width: auto;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+.ert-parameter-view-caption-tooltip {
+    background-color: rgba(56,108,176, 0.8);
+    color: white;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+

--- a/webviz_ert/views/parameter_view.py
+++ b/webviz_ert/views/parameter_view.py
@@ -16,74 +16,81 @@ def parameter_view(parent: WebvizPluginABC, index: int = 0) -> List[Component]:
             id={"index": index, "type": parent.uuid("parameter-id-store")}, data=index
         ),
         dbc.Row(
-            className="ert-plot-options",
             children=[
                 dbc.Col(
                     [
-                        dbc.Row(
-                            [
-                                dbc.Col(
-                                    [html.H4(index)],
-                                    align="center",
-                                ),
-                                dbc.Col(
-                                    [
-                                        html.Label("Plots:"),
-                                    ],
-                                    width="auto",
-                                    align="center",
-                                ),
-                                dbc.Col(
-                                    [
-                                        dcc.Checklist(
-                                            id={
-                                                "index": index,
-                                                "type": parent.uuid("hist-check"),
-                                            },
-                                            options=[
-                                                {"label": "histogram", "value": "hist"},
-                                                {"label": "kde", "value": "kde"},
-                                            ],
-                                            value=["hist", "kde"],
-                                            persistence="session",
-                                        ),
-                                    ],
-                                    align="center",
-                                ),
-                            ]
+                        html.H4(
+                            index,
+                            className="ert-parameter-view-caption",
+                            id={
+                                "index-caption": index,
+                                "type": parent.uuid("parameter-id-store"),
+                            },
                         )
                     ],
+                    align="left",
+                ),
+                dbc.Tooltip(
+                    index,
+                    target={
+                        "index-caption": index,
+                        "type": parent.uuid("parameter-id-store"),
+                    },
+                    placement="bottom-start",
+                    class_name="ert-parameter-view-caption-tooltip",
+                ),
+            ]
+        ),
+        dbc.Row(
+            children=[
+                dbc.Col(
+                    [
+                        html.Label("Plots:"),
+                    ],
+                    width="auto",
+                    align="left",
+                ),
+                dbc.Col(
+                    [
+                        dcc.Checklist(
+                            id={
+                                "index": index,
+                                "type": parent.uuid("hist-check"),
+                            },
+                            options=[
+                                {"label": "histogram", "value": "hist"},
+                                {"label": "kde", "value": "kde"},
+                            ],
+                            value=["hist", "kde"],
+                            persistence="session",
+                        ),
+                    ],
+                    align="left",
                     width="auto",
                 ),
                 dbc.Col(
                     [
-                        dbc.Row(
-                            [
-                                dbc.Col(
-                                    [
-                                        html.Label(
-                                            "Number of bins:", className="ert-label"
-                                        ),
-                                    ],
-                                    width="auto",
-                                ),
-                                dbc.Col(
-                                    [
-                                        dcc.Input(
-                                            id={
-                                                "index": index,
-                                                "type": parent.uuid("hist-bincount"),
-                                            },
-                                            type="number",
-                                            placeholder="# bins",
-                                            min=2,
-                                            debounce=True,
-                                        ),
-                                    ]
-                                ),
-                            ]
-                        )
-                    ]
+                        html.Label("Number of bins:", className="ert-label"),
+                    ],
+                    align="left",
+                    width="auto",
+                ),
+                dbc.Col(
+                    [
+                        dcc.Input(
+                            id={
+                                "index": index,
+                                "type": parent.uuid("hist-bincount"),
+                            },
+                            type="number",
+                            placeholder="# bins",
+                            min=2,
+                            debounce=True,
+                            className="ert-input-number",
+                        ),
+                    ],
+                    align="left",
+                    width="auto",
                 ),
                 dcc.Store(
                     id={"index": index, "type": parent.uuid("bincount-store")},


### PR DESCRIPTION
**Issue**
Resolves #245 

- Added a ... when name is too large.
- Added a tooltip with the complete parameter name
- Refactored the "options" to be on its own row below header

