### PR TITLE
Add hint to use config file during start up

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,8 @@ ert ensemble_smoother --target-case smoother poly.ert
 
 # After simulation has finished, start webviz-ert from the same location with
 ert vis
+
+# Alternatively, you might have to supply the config file if you're using the
+# classic ert storage solution:
+ert vis poly.ert
 ```


### PR DESCRIPTION
**Issue**
This came up while trying to start webviz ert for the first time.

Following the instructions from the readme to the dot, starting webviz-ert doesn't necessarily work - I had to supply a config file.


**Approach**

After discussing a bit in the team, we've concurred that adding this hint should be harmless.


## Pre review checklist

- [X] Added appropriate labels
