### PR TITLE
Handle ZeroDivisionError in bin_size

### DIFF
--- a/webviz_ert/models/plot_model.py
+++ b/webviz_ert/models/plot_model.py
@@ -318,7 +318,11 @@ class MultiHistogramPlotModel:
             return go.Figure()
         _max = float(np.hstack(data).max())
         _min = float(np.hstack(data).min())
-        bin_size = float((_max - _min) / self.bin_count)
+        try:
+            bin_size = float((_max - _min) / self.bin_count)
+        except ZeroDivisionError:
+            bin_size = 1.0
+
         fig = ff.create_distplot(
             data,
             names,


### PR DESCRIPTION
**Issue**
Resolves #274 


**Approach**
Handle exception and set value of bin size to the default of `ff.create_distplot`, which is 1.

Before: 
<img width="1592" alt="Screenshot 2022-06-14 at 11 38 24" src="https://user-images.githubusercontent.com/62240435/173550500-7d822728-9493-4e65-be29-90354f457088.png">

After:
<img width="1598" alt="Screenshot 2022-06-14 at 11 21 55" src="https://user-images.githubusercontent.com/62240435/173550567-e6673c59-1bbc-4cca-99b6-86e4578485d7.png">


I did not add any tests, but maybe I should consider it?