### PR TITLE
Separate plots in plot viewer

### DIFF
--- a/webviz_ert/plugins/_response_comparison.py
+++ b/webviz_ert/plugins/_response_comparison.py
@@ -118,4 +118,9 @@ class ResponseComparison(WebvizErtPluginABC):
         webviz_ert.controllers.parameter_selector_controller(
             self, app, data_type=DataType.RESPONSE, extra_input=True
         )
-        webviz_ert.controllers.plot_view_controller(self, app)
+        webviz_ert.controllers.plot_view_controller(
+            self, app, webviz_ert.models.DataType.RESPONSE
+        )
+        webviz_ert.controllers.plot_view_controller(
+            self, app, webviz_ert.models.DataType.PARAMETER
+        )

--- a/webviz_ert/views/parameter_view.py
+++ b/webviz_ert/views/parameter_view.py
@@ -9,7 +9,7 @@ import dash_bootstrap_components as dbc
 import webviz_ert.assets as assets
 
 
-def parameter_view(parent: WebvizPluginABC, index: int = 0) -> List[Component]:
+def parameter_view(parent: WebvizPluginABC, index: str = "") -> List[Component]:
     return [
         dcc.Store(
             id={"index": index, "type": parent.uuid("parameter-id-store")}, data=index

--- a/webviz_ert/views/plot_view.py
+++ b/webviz_ert/views/plot_view.py
@@ -47,14 +47,18 @@ def plot_view_header(parent: WebvizErtPluginABC) -> List[Component]:
                 ),
             ]
         ),
-        dcc.Store(id=parent.uuid("plot-selection-store"), storage_type="session"),
+        dcc.Store(id=parent.uuid("plot-selection-store-resp"), storage_type="session"),
+        dcc.Store(id=parent.uuid("plot-selection-store-param"), storage_type="session"),
     ]
 
 
 def plot_view_body(parent: WebvizErtPluginABC) -> List[Component]:
     return [
         html.Div(
-            [dbc.Row(children=[], id=parent.uuid("plotting-content"))],
+            [
+                dbc.Row(children=[], id=parent.uuid("plotting-content-resp")),
+                dbc.Row(children=[], id=parent.uuid("plotting-content-param")),
+            ],
             id=parent.uuid("plotting-content-container"),
         ),
     ]

--- a/webviz_ert/views/response_view.py
+++ b/webviz_ert/views/response_view.py
@@ -7,7 +7,7 @@ from dash import dcc
 import dash_bootstrap_components as dbc
 
 
-def response_view(parent: WebvizPluginABC, index: int = 0) -> List[Component]:
+def response_view(parent: WebvizPluginABC, index: str = "") -> List[Component]:
     return [
         dcc.Store(
             id={"index": index, "type": parent.uuid("response-id-store")}, data=index


### PR DESCRIPTION
**Issue**
Closes #268 


**Approach**
We arrange the response plots in one row, and the parameter plots in another row.
To this end, we parametrize the parameter / response duality in the plot view controller instead of handling both at once, and call two instances of the controller, one for responses and one for parameters, respectively.

## Pre review checklist

- [X] Added appropriate labels
