### PR TITLE
Refactor select_first function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,10 +72,10 @@ def _requests_post(url, **kwargs):
 
 
 def select_first(dash_duo, selector):
-    parameter_selector_input = dash_duo.find_element(selector)
-    options = parameter_selector_input.text.split("\n")
-    dash_duo.click_at_coord_fractions(parameter_selector_input, 0.1, 0.05)
-    return options[0]
+    options = dash_duo.find_elements(selector + " option")
+    name = options[0].text
+    options[0].click()
+    return name
 
 
 def select_by_name(dash_duo, selector, name):


### PR DESCRIPTION
Instead of clicking a coordinate, just pick the list of options
and click the first one. The motivation for the refactoring is
tests started breaking due to a change in selenium
move_to_element_with_offset() which currently tries to use the
top left corner of the element as the origin; in Selenium 4.3
it will use the in-view center point of the element as the origin.