### PR TITLE
Show realization number in misfit plots

### DIFF
--- a/tests/plots/test_controller.py
+++ b/tests/plots/test_controller.py
@@ -177,13 +177,19 @@ def test_parallel_coordinates_representation():
 def test_univariate_misfits_boxplot_representation():
     data = np.random.rand(200).reshape(-1, 20)
     missfits_df = pd.DataFrame(data=data, index=range(10), columns=range(20))
-    plots = _get_univariate_misfits_boxplots(missfits_df.copy(), color="rgb(255,0,0)")
+    ensemble_name = "test-ensemble"
+    plots = _get_univariate_misfits_boxplots(
+        missfits_df.copy(), ensemble_name=ensemble_name, color="rgb(255,0,0)"
+    )
     assert len(plots) == 20
     for id_plot, plot in enumerate(plots):
         np.testing.assert_equal(0.3, plot.repr.jitter)
         np.testing.assert_equal("all", plot.repr.boxpoints)
         x_pos = missfits_df.columns[id_plot]
-        name = f"{x_pos}"
+        if isinstance(x_pos, int):
+            name = f"Value {x_pos}"
+        else:
+            name = f"{x_pos} - {ensemble_name}"
         assert name == plot.repr.name
 
 

--- a/webviz_ert/models/plot_model.py
+++ b/webviz_ert/models/plot_model.py
@@ -108,16 +108,27 @@ class BoxPlotModel:
         self._y_axis = kwargs["y_axis"]
         self._name = kwargs["name"]
         self._color = kwargs["color"]
+        self._customdata = kwargs["customdata"] if "customdata" in kwargs else None
+        self._hovertemplate = (
+            kwargs["hovertemplate"] if "hovertemplate" in kwargs else None
+        )
+        self._ensemble_name = (
+            kwargs["ensemble_name"] if "ensemble_name" in kwargs else None
+        )
 
     @property
     def repr(self) -> go.Box:
         repr_dict = dict(
             y=self._y_axis,
+            x0=f"{self._name}",
+            legendgroup=self.name,
             name=self.display_name,
             boxpoints="all",
             jitter=0.3,
             pointpos=-1.8,
             marker_color=self._color,
+            customdata=self._customdata,
+            hovertemplate=self._hovertemplate,
         )
 
         return go.Box(repr_dict)
@@ -131,7 +142,11 @@ class BoxPlotModel:
         if isinstance(self._name, int):
             return f"Value {self._name}"
         else:
-            return self._name
+            return (
+                f"{self._name} - {self._ensemble_name}"
+                if self._ensemble_name
+                else self._name
+            )
 
 
 class BarChartPlotModel:


### PR DESCRIPTION
**Issue**
Closes #289 


**Approach**
This concerns two different plots in the misfits plugin aka Observation Analyzer - the univariate view (bunch of boxplots), and the summary histograms.

For the bosplots, we use `customdata` to supply the realization numbers and insert it into the hover text by overriding the `hovertemplate`.

For the summary, #92 already did most of the work - we only needed to transpose the misfits dataframe in question.

Please test this with data, in particular also with several ensembles chosen (as the example I used for manual testing only had one ensemble).


## Pre review checklist

- [X] Added appropriate labels
