### PR TITLE
Finish test for axes labels

### DIFF
--- a/tests/views/test_response_correlation.py
+++ b/tests/views/test_response_correlation.py
@@ -98,8 +98,7 @@ def test_axes_labels(mock_data, dash_duo):
         )
         selected_response_closer.click()
 
-    # wait for deselected option to reappear among available options
-    # response_selector_id = plugin.uuid("parameter-selector-multi-resp")
-    # dash_duo.wait_for_element(f"#{response_selector_id}
+        # wait for deselected option to reappear among available options
+        dash_duo.wait_for_contains_text(f"#{response_selector_id}", wanted_response)
 
     # assert dash_duo.get_logs() == [], "browser console should contain no error"


### PR DESCRIPTION
We had left one check commented out that was to be made into meaningful
code. As the test was passing (aside from the flakiness mentioned in
issue #297), this extra check was perhaps not really necessary, and were
not sure if it might help with the mentioned flakiness either.

Closes #306

## Pre review checklist

- [X] Added appropriate labels
