### PR TITLE
Fix bug of moving selection of vertical line

### DIFF
--- a/webviz_ert/controllers/response_correlation_controller.py
+++ b/webviz_ert/controllers/response_correlation_controller.py
@@ -213,17 +213,18 @@ def response_correlation_controller(parent: WebvizErtPluginABC, app: dash.Dash) 
                 for obs in response.observations:
                     obs_plots.append(_get_observation_plots(obs.data_df()))
 
-                x_axis_default_observation = _get_first_observation_x(
-                    response.observations[0].data_df()
-                )
-                if isinstance(x_axis, pd.Index):
-                    corr_xindex[selected_response] = x_axis.get_loc(
-                        x_axis_default_observation
+                if corr_xindex[selected_response] == 0:
+                    x_axis_default_observation = _get_first_observation_x(
+                        response.observations[0].data_df()
                     )
-                elif isinstance(x_axis, list):
-                    corr_xindex[selected_response] = x_axis.index(
-                        x_axis_default_observation
-                    )
+                    if isinstance(x_axis, pd.Index):
+                        corr_xindex[selected_response] = x_axis.get_loc(
+                            x_axis_default_observation
+                        )
+                    elif isinstance(x_axis, list):
+                        corr_xindex[selected_response] = x_axis.index(
+                            x_axis_default_observation
+                        )
 
         fig = go.Figure()
         for plot in plots:


### PR DESCRIPTION
**Issue**
Resolves #324


**Approach**
The problem was only observed for responses with observation.
The solution was to add an if statement before updating where the vertical line should be displayed.
The problem of this solution is that it wont be possible to select the index 0.
I don't see this as a problem, as the request of the user indicated that the index 0 does aggregate value to the analysis.
