### PR TITLE
Fix ensemble handling in response correlation viewer

### DIFF
--- a/webviz_ert/controllers/response_correlation_controller.py
+++ b/webviz_ert/controllers/response_correlation_controller.py
@@ -90,7 +90,8 @@ def response_correlation_controller(parent: WebvizErtPluginABC, app: dash.Dash) 
             and responses
             and corr_param_resp["response"] in responses
         ):
-            raise PreventUpdate
+            return ({}, {})
+
         selected_response = corr_param_resp["response"]
         data = {}
         colors = {}
@@ -382,7 +383,7 @@ def response_correlation_controller(parent: WebvizErtPluginABC, app: dash.Dash) 
         else:
             ensembles = None
         if not (ensembles and responses and corr_param_resp["response"] in responses):
-            raise PreventUpdate
+            return {}
         selected_response = corr_param_resp["response"]
         loaded_ensembles = [
             load_ensemble(parent, ensemble_id) for ensemble_id in ensembles
@@ -484,7 +485,7 @@ def response_correlation_controller(parent: WebvizErtPluginABC, app: dash.Dash) 
             and corr_param_resp["parameter"] in parameters
             and corr_param_resp["response"] in responses
         ):
-            raise PreventUpdate
+            return ({}, [])
 
         selected_parameter = corr_param_resp["parameter"]
         selected_response = corr_param_resp["response"]


### PR DESCRIPTION
**Issue**
Resolves #326


**Approach**
We
- use the store instead of html elements to fetch info about which ensembles are selected and
- return blank (graph) objects instead of raising a don't-update-exception

**Testing**
We thought about adding regression tests, but it turned out to be at least difficult - I could not see any immediate way of querying the DOM using the dash duo testing api to figure out whether a graph was drawn, or not.

## Pre review checklist

- [X] Added appropriate labels

