### PR TITLE
Refactor `update_corr_resp_param`

### DIFF
--- a/webviz_ert/plugins/_response_correlation.py
+++ b/webviz_ert/plugins/_response_correlation.py
@@ -33,15 +33,16 @@ class ResponseCorrelation(WebvizErtPluginABC):
             {
                 "id": self.uuid("response-overview"),
                 "content": (
-                    "Visualization of the currently selected response "
-                    "where by clicking we can select a new index / timestep for correlation analysis."
+                    "Visualization of the currently active response "
+                    "where by clicking we can select a new active index / "
+                    "timestep for correlation analysis."
                 ),
             },
             {
                 "id": self.uuid("response-scatterplot"),
                 "content": (
-                    "Scatterplot visualization of function values between currently selected "
-                    "response and currently selected parameter. "
+                    "Scatterplot visualization of function values between currently active "
+                    "response and currently active parameter. "
                     "It is accompanied by distribution plots for both selections. "
                 ),
             },
@@ -49,7 +50,7 @@ class ResponseCorrelation(WebvizErtPluginABC):
                 "id": self.uuid("response-heatmap"),
                 "content": (
                     "Heatmap based representation of correlation (-1, 1) among all selected responses "
-                    "and parameters, for currently active ensembles in column-wise fashion."
+                    "and parameters, for currently selected ensembles in column-wise fashion."
                     "One can select a currently active response and parameter "
                     "by clicking directly on a heatmap. "
                 ),
@@ -57,7 +58,7 @@ class ResponseCorrelation(WebvizErtPluginABC):
             {
                 "id": self.uuid("response-correlation"),
                 "content": (
-                    "Correlation BarChart for the single selected response (from heatmap) "
+                    "Correlation BarChart for the currently active response (from heatmap) "
                     "and parameters in a descending order. "
                 ),
             },
@@ -95,7 +96,7 @@ class ResponseCorrelation(WebvizErtPluginABC):
                     data={},
                 ),
                 dash.dcc.Store(
-                    id=self.uuid("correlation-store-selection"),
+                    id=self.uuid("correlation-store-active-resp-param"),
                     data=self.load_state(
                         "active_correlation",
                         {"parameter": None, "response": None},


### PR DESCRIPTION
**Issue**
Resolves #336


**Approach**

- refactor the logic of data handling in the callback function
- add a doc string describing the expected behaviour of the callback function
- rename the callback function, the store, and variables derived from said store

**Notes for reviewer**
Please have a critical look at the logic refactoring of the callback - I don't know if I actually improved it (much).

The checks in various other callbacks of the form

```
active_resp_param["parameter"] in parameters
```

are left in place, even though they were what originally made me stumble upon this function - they are strictly speaking not necessary, as an unselected parameter (`parameters` contains the selected parameters) will never be active (and deselection of an active parameter shifts active state to another selected parameter). Nevertheless I decided not to remove them, to continue with the idea of defensive programming.

Now it really makes me wonder though if one should leave it in, because it has the tendency to confuse people (or at least me!) - you just have to wonder, is this possible state?! but perhaps thanks to the docs it's clear what is possible state and what is not. also, the defensive approach could be argued as isolation of callback between one another - one callback should not rely exactly on the implementation of another callback? I don't know...

## Pre review checklist

- [X] Added appropriate labels
