### PR TITLE
Import of ert_shared -> ert.shared

### DIFF
--- a/tests/data/spe1_st/tests/conftest.py
+++ b/tests/data/spe1_st/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.fixture(scope="session")
 def get_info():
-    from ert_shared.services import Storage
+    from ert.shared.services import Storage
 
     with Storage.start_server() as service:
         yield service.fetch_url(), service.fetch_auth()[1]

--- a/webviz_ert/data_loader/__init__.py
+++ b/webviz_ert/data_loader/__init__.py
@@ -13,7 +13,7 @@ connection_info_map: dict = {}
 
 
 def get_connection_info(project_id: str = None) -> Mapping[str, str]:
-    from ert_shared.storage.connection import get_info
+    from ert.shared.storage.connection import get_info
 
     if project_id not in connection_info_map:
         info = get_info(project_id)


### PR DESCRIPTION
**Issue**
`ert_shared` is refactored in `ert` and moved to `ert/shared`  


**Approach**
Fix the import statements


## Pre review checklist

- [x] Added appropriate labels
