### PR TITLE
Fix index for clicking on observation

### DIFF
--- a/webviz_ert/controllers/multi_response_controller.py
+++ b/webviz_ert/controllers/multi_response_controller.py
@@ -79,7 +79,9 @@ def _get_realizations_statistics_plots(
     return [mean_data, lower_std_data, upper_std_data]
 
 
-def _get_observation_plots(observation_df: pd.DataFrame) -> PlotModel:
+def _get_observation_plots(
+    observation_df: pd.DataFrame, metadata: List[str] = None
+) -> PlotModel:
     data = observation_df["values"]
     stds = observation_df["std"]
     x_axis = observation_df["x_axis"]
@@ -100,6 +102,7 @@ def _get_observation_plots(observation_df: pd.DataFrame) -> PlotModel:
             array=stds.values,
             visible=True,
         ),
+        meta=metadata,
         **style,
     )
     return observation_data

--- a/webviz_ert/models/plot_model.py
+++ b/webviz_ert/models/plot_model.py
@@ -205,6 +205,7 @@ class PlotModel:
         self._marker = kwargs["marker"]
         self._error_y = kwargs.get("error_y")
         self._hoverlabel = kwargs.get("hoverlabel")
+        self._meta = kwargs["meta"] if "meta" in kwargs else None
         self.selected = True
 
     @property
@@ -218,6 +219,7 @@ class PlotModel:
             error_y=self._error_y,
             connectgaps=True,
             hoverlabel=self._hoverlabel,
+            meta=self._meta,
         )
         if self._line:
             repr_dict["line"] = self._line

--- a/webviz_ert/models/response.py
+++ b/webviz_ert/models/response.py
@@ -34,7 +34,7 @@ class Response:
         return self._ensemble_id
 
     @property
-    def axis(self) -> Optional[List[Union[int, str, datetime.datetime]]]:
+    def axis(self) -> pd.Index:
         return self.data.index
 
     @property


### PR DESCRIPTION
Closes #369

**Approach**
We check whether the click was right on an observation, and do a reverse lookup of the clicked x value in the response axis - the previously used clicked index for an observation point refers to the observation axis, which is potentially shorter than the response axis.


## Pre review checklist

- [x] Added appropriate labels
