### PR TITLE
Use namespaced class for selectors

### DIFF
--- a/webviz_ert/assets/ert-style.css
+++ b/webviz_ert/assets/ert-style.css
@@ -62,7 +62,7 @@
   color: black;
 }
 
-.webviz-config-select {
+.ert-select-variable {
 	height: 15rem;
 }
 .active-info {

--- a/webviz_ert/views/ensemble_selector_view.py
+++ b/webviz_ert/views/ensemble_selector_view.py
@@ -47,6 +47,7 @@ def ensemble_selector_list(parent: WebvizErtPluginABC) -> List[Component]:
                 persistence_type="session",
                 options=[],
                 value=[],
+                className="ert-select-variable",
             ),
             id=parent.uuid("container-ensemble-selector-multi"),
             className="ert-ensemble-selector-container-show",

--- a/webviz_ert/views/selector_view.py
+++ b/webviz_ert/views/selector_view.py
@@ -52,6 +52,7 @@ def parameter_selector_view(
                     multi=True,
                     size=10,
                     persistence="session",
+                    className="ert-select-variable",
                 ),
                 id=parent.uuid(f"container-parameter-selector-multi-{data_type}"),
                 className="ert-parameter-selector-container-show",


### PR DESCRIPTION
Due to webviz build setup, and the way we bundle software at equinor
(komodo), class names in our assets can affect other webviz apps which
do not refer to our codebase in any way.

We should always use namespaced class names for modifying CSS properties
rather then the first existing name we find.


**Approach**
Use `ert-select-variable` instead of `webviz-config-select`


## Pre review checklist

- [X] Added appropriate labels
