### PR TITLE
Changes need to moving webviz-ert state file to ensemble path

### DIFF
--- a/webviz_ert/__main__.py
+++ b/webviz_ert/__main__.py
@@ -16,7 +16,10 @@ logger = logging.getLogger()
 
 
 def run_webviz_ert(
-    title: str, experimental_mode: bool = False, verbose: bool = False
+    title: str,
+    experimental_mode: bool = False,
+    verbose: bool = False,
+    project_identifier: Optional[str] = None,
 ) -> None:
     signal.signal(signal.SIGINT, handle_exit)
     # The entry point of webviz is to call it from command line, and so do we.
@@ -25,9 +28,8 @@ def run_webviz_ert(
     if webviz:
         send_ready()
         with tempfile.NamedTemporaryFile() as temp_config:
-            project_identifier = os.getenv("ERT_PROJECT_IDENTIFIER", os.getcwd())
             if project_identifier is None:
-                logger.error("Unable to find ERT project!")
+                project_identifier = os.getcwd()
             create_config(
                 title, project_identifier, WEBVIZ_CONFIG, temp_config, experimental_mode
             )
@@ -120,6 +122,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--title", help="Set title of html document", default="ERT - Visualization tool"
     )
+    parser.add_argument(
+        "--project_identifier", help="Set title of html document", default=os.getcwd()
+    )
+
     args = parser.parse_args()
 
-    run_webviz_ert(args.title, args.experimental_mode, args.verbose)
+    run_webviz_ert(
+        args.title, args.experimental_mode, args.verbose, args.project_identifier
+    )

--- a/webviz_ert/plugins/_webviz_ert.py
+++ b/webviz_ert/plugins/_webviz_ert.py
@@ -10,7 +10,7 @@ import tempfile
 class WebvizErtPluginABC(WebvizPluginABC):
     _ensembles: MutableMapping[str, "EnsembleModel"] = {}
     _state: MutableMapping[str, Any] = {}
-    _state_file_name: str = "last_known_state.json"
+    _state_file_name: str = "webviz_ert_state.json"
     _state_path: Optional[pathlib.Path] = None
 
     def __init__(self, app: dash.Dash, project_identifier: str):
@@ -29,7 +29,7 @@ class WebvizErtPluginABC(WebvizPluginABC):
         if not WebvizErtPluginABC._state:
             if WebvizErtPluginABC._state_path is None:
                 WebvizErtPluginABC._state_path = (
-                    project_root / f".webviz/{WebvizErtPluginABC._state_file_name}"
+                    project_root / f"{WebvizErtPluginABC._state_file_name}"
                 )
             if not WebvizErtPluginABC._state_path.exists():
                 WebvizErtPluginABC._state_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
**Issue**
Changes  in preparation for https://github.com/equinor/ert/pull/3890


**Approach**
Fix propagation of `project_identifier` path
Move file where `webviz-ert` page state is saved outside of `.webviz` folder directly inside the `project_identifier` path

## Pre review checklist

- [ ] Added appropriate labels
