### PR TITLE
Update location of ert services

### DIFF
--- a/tests/data/spe1_st/tests/conftest.py
+++ b/tests/data/spe1_st/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope="session", autouse=True)
 def start_storage_server():
-    from ert.shared.services import Storage
+    from ert.services import Storage
 
     with Storage.start_server() as service:
         service.wait_until_ready(timeout=30)


### PR DESCRIPTION
The location of ert services has moved in ert=4.0.0-b0. This updates the path which is used only in the spe1 integration test. It seems `webviz-ert` runs the spe1 integration test on whatever is deployed in komodo bleeding, so the timing of this merge depends on the state of what is deployed.

## Pre review checklist

- [x] Added appropriate labels
