### PR TITLE
Update chromedriver supporting chromium 108

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -20,7 +20,7 @@ start_tests () {
 start_integration_test () {
 
     echo "Downloading chromedriver ..."
-    wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/103.0.5060.134/chromedriver_linux64.zip
+    wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/108.0.5359.71/chromedriver_linux64.zip
     unzip chromedriver.zip chromedriver -d ../test-kenv/root/bin
 
     pip install pytest selenium dash[testing]


### PR DESCRIPTION
**Issue**
Testing of GUI requires chromedrivers supporting the chromium installation to be installed in the test-environment. Chromium is now updated to version 108.xx and needs a new chromedriver.


