### PR TITLE
register pytest mark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,7 @@
 requires = ["setuptools", "setuptools_scm", "wheel"]
 
 [tool.pytest.ini_options]
-addopts = "-k 'not spe1'"
+addopts = "-m 'not spe1'"
+markers = [
+    "spe1: marks tests needing results from ert model of the spe1 test case",
+]


### PR DESCRIPTION
The mark is present in the tests but not registered. This commit registers it in `pyproject.toml` and uses it for the default test selection instead of -k.

**Issue**
Resolves #408 

**Approach**
Register the mark in the init file.


## Pre review checklist

- [ ] Added appropriate labels
