### PR TITLE
Install chromedriver to match installed chromium

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -19,8 +19,10 @@ start_tests () {
 
 start_integration_test () {
 
-    echo "Downloading chromedriver ..."
-    wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/108.0.5359.71/chromedriver_linux64.zip
+    chromium_version=$(chromium-browser --version | grep -zoP '\d+\.\d+\.\d+')
+    chromedriver_version=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$chromium_version)
+    echo "Downloading chromedriver v$chromedriver_version for chromium-browser v$chromium_version"
+    wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/$chromedriver_version/chromedriver_linux64.zip
     unzip chromedriver.zip chromedriver -d ../test-kenv/root/bin
 
     pip install pytest selenium dash[testing]


### PR DESCRIPTION
Instead of having to update the chromedriver to match the browser whenever the test breaks, we can ask Google's chromedriver API for the correct version dynamically. This should let us cope with the possibility of having to run tests on different platforms, with potentially different versions of Chrome/Chromium.

**Issue**
Resolves #414


**Approach**
Rather than installing chromium ourselves (which would be slow), or using a 3rd party lirbary to detect or install the right version (which adds a dependency), and taking advantage of [Google's API](https://chromedriver.chromium.org/downloads/version-selection) for this, we add a couple of extra steps to `testkomodo.sh`.


## Pre review checklist

- [x] Added appropriate labels
