### PR TITLE
unset HOST env var before integration test

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -30,12 +30,15 @@ start_integration_test () {
     pushd tests/data/spe1_st
 
     echo "Initiating Ert run for Spe1 with new storage enabled..."
-
     ert ensemble_experiment --enable-new-storage spe1.ert
-
     echo "Ert ensemble_experiment run finished"
 
-    echo "Test for webviz-ert plugins ..."
+    # $HOST is set to machine name for f_komodo user's bash shells.
+    # Must unset for Dash to use localhost as server name, as Selenium expects.
+    unset HOST
+
+    echo "Test for webviz-ert plugins..."
     pytest ../../../ -vs -m spe1
+
     popd
 }


### PR DESCRIPTION
Only the f_komodo user seems to have  set in in bash. when the Dash server starts it picks up  for the server name, but Selenium is looking for 127.0.0.1 or localhost.

**Issue**
Resolves #411


**Approach**
Unset the environment variable before running the tests.


## Pre review checklist

- [x] Added appropriate labels
