### PR TITLE
Make license consistent in PyPI and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![PyPI version](https://badge.fury.io/py/webviz-ert.svg)](https://badge.fury.io/py/webviz-ert)
 [![Build Status](https://github.com/equinor/webviz-ert/workflows/Python/badge.svg)](https://github.com/equinor/webviz-ert/actions?query=workflow%3APython)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![PyPI license](https://img.shields.io/pypi/l/webviz-ert.svg)](https://pypi.org/project/webviz-ert/)
 
 # Web based visualization for ERT
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,10 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Dash",
         "Framework :: Flask",
+        "Topic :: Scientific/Engineering",
+        "Intended Audience :: Science/Research",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     ],
 )


### PR DESCRIPTION
The wrong license was hardcoded into the README badge. This update instead gets it from PyPI, which in turn uses the project metadata. Since the metadata was not set, I added it to setup.py -- so it won't appear in PyPI until the next release. After that, all will be good.

I also took the opportunity to add a bit more metadata.

**Issue**
Resolves #410


**Approach**
Use PyPI metadata for badge.


## Pre review checklist

- [x] Added appropriate labels
