### PR TITLE
Fix flaky test on self-hosted runner

### DIFF
--- a/tests/views/test_response_correlation.py
+++ b/tests/views/test_response_correlation.py
@@ -30,8 +30,9 @@ def test_axes_labels(mock_data, dash_duo):
 
         plot_id = plugin.uuid("response-overview")
 
-        # check that y axis label spells out "Value"
-        dash_duo.wait_for_text_to_equal(f"#{plot_id} text.ytitle", "Value")
+        # check that y axis label spells out "Value"; test is flaky so longer
+        # timeout.
+        dash_duo.wait_for_text_to_equal(f"#{plot_id} text.ytitle", "Value", timeout=20)
 
         # check that one has date, the other has index as x axis label
         if wanted_response == "FOPR":


### PR DESCRIPTION
One of the Selenium tests on a plot axis title was sometimes timing out. This change doubles the timeout to 20s. For sure, 10s already seems long; if there's still an issue it may be another problem.

**Issue**
Resolves #418


**Approach**
Double the length of the timeout.


## Pre review checklist

- [x] Added appropriate labels
