### PR TITLE
Unpack zip with new path

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -28,12 +28,13 @@ start_integration_test () {
     then
         echo "Downloading chromedriver v$chromium_version for chromium-browser v$chromium_version"
         wget -O chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$chromium_version/linux64/chromedriver-linux64.zip
+        unzip -j chromedriver.zip chromedriver-linux64/chromedriver -d ../test-kenv/root/bin
     else
         chromedriver_version=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$chromium_minor_version)
         echo "Downloading chromedriver v$chromedriver_version for chromium-browser v$chromium_version"
         wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/$chromedriver_version/chromedriver_linux64.zip
+        unzip chromedriver.zip chromedriver -d ../test-kenv/root/bin
     fi
-    unzip chromedriver.zip chromedriver -d ../test-kenv/root/bin
 
     pip install pytest selenium dash[testing]
 


### PR DESCRIPTION
**Issue**
Resolves #440 


**Approach**
Doing the unzip as part of the conditional too now. Seems to work:

```
(kenv-ert + 2023.06.03-py38-rhel7) [mtha@s034-rgs0002 deleteme]$ unzip -j chromedriver.zip chromedriver-linux64/chromedriver -d ../test-kenv/root/bin
Archive:  chromedriver.zip
  inflating: ../test-kenv/root/bin/chromedriver  
(kenv-ert + 2023.06.03-py38-rhel7) [mtha@s034-rgs0002 deleteme]$ ../test-kenv/root/bin/chromedriver 
Starting ChromeDriver 115.0.5790.110 (5e87dfef0c85687ea835e444d33466745cc0725f-refs/branch-heads/5790_90@{#20}) on port 9515
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
```


## Pre review checklist

- [ ] Added appropriate labels
