### PR TITLE
Remove old chromedriver download method

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -23,18 +23,9 @@ start_integration_test () {
     chromium_major_version=$(echo $chromium_version | grep -zoP '^\d+')
     chromium_minor_version=$(echo $chromium_version | grep -zoP '^\d+\.\d+\.\d+')
 
-    # Until Chromium is upgrade to v115+ on onprem RGS nodes, we need two different download methods.
-    if [ "$chromium_major_version" -ge 115 ];
-    then
-        echo "Downloading chromedriver v$chromium_version for chromium-browser v$chromium_version"
-        wget -O chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$chromium_version/linux64/chromedriver-linux64.zip
-        unzip -j chromedriver.zip chromedriver-linux64/chromedriver -d ../test-kenv/root/bin
-    else
-        chromedriver_version=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$chromium_minor_version)
-        echo "Downloading chromedriver v$chromedriver_version for chromium-browser v$chromium_version"
-        wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/$chromedriver_version/chromedriver_linux64.zip
-        unzip chromedriver.zip chromedriver -d ../test-kenv/root/bin
-    fi
+    echo "Downloading chromedriver v$chromium_version for chromium-browser v$chromium_version"
+    wget -O chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$chromium_version/linux64/chromedriver-linux64.zip
+    unzip -j chromedriver.zip chromedriver-linux64/chromedriver -d ../test-kenv/root/bin
 
     pip install pytest selenium dash[testing]
 


### PR DESCRIPTION
This leaves only the new download method, since v115. Resolves #439.
