### PR TITLE
Add python 3.11 and 3.12 to tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,14 +8,19 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.11", "3.12"]
+        os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "${{ matrix.python-version }}"
     - name: Install
       run: |
         pip install .


### PR DESCRIPTION
Run the tests with Python 3.11 and 3.12.


## Pre review checklist

- [ ] Added appropriate labels
