### PR TITLE
Make webviz ert support pandas 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "dash-bootstrap-components",
         "dash-daq",
-        "pandas<2",
+        "pandas",
         "requests",
         "webviz-config>=0.0.40",
         "webviz-config-equinor",

--- a/webviz_ert/data_loader/__init__.py
+++ b/webviz_ert/data_loader/__init__.py
@@ -1,9 +1,10 @@
-from typing import Any, Mapping, Optional, List, MutableMapping, Tuple, Dict
-from collections import defaultdict
-import requests
-import logging
-import pandas as pd
 import io
+import logging
+from collections import defaultdict
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Tuple
+
+import pandas as pd
+import requests
 
 logger = logging.getLogger()
 
@@ -194,10 +195,9 @@ class DataLoader:
         except DataLoaderException as e:
             logger.error(e)
             return pd.DataFrame()
-
         try:
             df.index = df.index.astype(int)
-        except TypeError:
+        except (TypeError, ValueError):
             try:
                 df.index = df.index.map(pd.Timestamp)
             except ValueError:


### PR DESCRIPTION
**Issue**
Resolves #432 

When pandas fails to convert dataframe index type to int, it seemingly  now throws a ValueError instead of a TypeError in pandas 2.

## Pre review checklist

- [ ] Added appropriate labels
