### PR TITLE
Remove unused install function in testkomodo.sh

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -3,10 +3,6 @@ copy_test_files () {
     cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
 }
 
-install_package () {
-    pip install . --no-deps
-}
-
 start_tests () {
     start_integration_test
     test_result=$?


### PR DESCRIPTION
I can not see that this is in use, and this function would potentially reinstall the entire package. When testing webviz-ert the dependencies is instead installed via the default install_test_dependencies in komodo/func_def.sh. 
