### PR TITLE
Mark browser-tests for conditional executions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,18 +8,6 @@ from selenium import webdriver
 from tests.data.snake_oil_data import ensembles_response
 
 
-def validate_chromedriver():
-    try:
-        driver = webdriver.Chrome()
-        browser_version = driver.capabilities["browserVersion"]
-        chromedriver_version = driver.capabilities["chrome"][
-            "chromedriverVersion"
-        ].split(" ")[0]
-        return browser_version[0:3] == chromedriver_version[0:3]
-    except (WebDriverException, TypeError):
-        return False
-
-
 def pytest_addoption(parser):
     parser.addoption(
         "--skip-browser-tests",
@@ -39,12 +27,10 @@ def pytest_collection_modifyitems(config, items):
     skip_browser_tests = pytest.mark.skip(
         reason="chromedriver missing in PATH or intentionally skipped"
     )
-    valid_chromedriver = validate_chromedriver()
     browser_tests = [item for item in items if "browser_test" in item.keywords]
-    if valid_chromedriver and not config.getoption("--skip-browser-tests"):
-        return
-    for item in browser_tests:
-        item.add_marker(skip_browser_tests)
+    if config.getoption("--skip-browser-tests"):
+        for item in browser_tests:
+            item.add_marker(skip_browser_tests)
 
 
 def pytest_setup_options():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,7 @@ import pytest
 from requests import HTTPError
 import dash
 from selenium.webdriver.chrome.options import Options
-from selenium.common.exceptions import TimeoutException, WebDriverException
-from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
 
 from tests.data.snake_oil_data import ensembles_response
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def pytest_addoption(parser):
         "--skip-browser-tests",
         action="store_true",
         default=False,
-        help="Allow forcing tests requiring chromedriver even it's missing in PATH",
+        help="This option allows skipping tests that depend on chromedriver",
     )
 
 

--- a/tests/views/test_ensemble_selector.py
+++ b/tests/views/test_ensemble_selector.py
@@ -1,4 +1,5 @@
 import dash
+import pytest
 from webviz_ert.assets import get_color
 from webviz_ert.plugins import ParameterComparison
 from tests.conftest import select_first, get_options
@@ -6,6 +7,7 @@ from tests.data.snake_oil_data import all_ensemble_names
 from tests.conftest import setup_plugin, select_ensemble
 
 
+@pytest.mark.browser_test
 def test_ensemble_refresh(
     mock_data,
     dash_duo,
@@ -84,6 +86,7 @@ def test_ensemble_refresh(
     )
 
 
+@pytest.mark.browser_test
 def test_ensemble_color(mock_data, dash_duo):
     plugin = setup_plugin(dash_duo, __name__, ParameterComparison, (630, 1200))
 

--- a/tests/views/test_general_stuff.py
+++ b/tests/views/test_general_stuff.py
@@ -23,6 +23,7 @@ from webviz_ert.plugins import (
         pytest.param(ResponseCorrelation, False),
     ],
 )
+@pytest.mark.browser_test
 def test_displaying_beta_warning(plugin_class, input: bool, dash_duo):
     plugin = setup_plugin(dash_duo, __name__, plugin_class, beta=input)
     beta_warning_element = dash_duo.find_element("#" + plugin.uuid("beta-warning"))
@@ -46,6 +47,7 @@ skip_parameters = "param"
         pytest.param(ResponseCorrelation, [], id="ResponseCorrelation"),
     ],
 )
+@pytest.mark.browser_test
 def test_selectors_visibility_toggle_button(plugin_class, skip, mock_data, dash_duo):
     # we test whether the selector visibility toggle button changes class on
     # all selectors, as expected
@@ -79,6 +81,7 @@ def test_selectors_visibility_toggle_button(plugin_class, skip, mock_data, dash_
     # assert dash_duo.get_logs() == [], "browser console should contain no error"
 
 
+@pytest.mark.browser_test
 def test_response_selector_sorting(mock_data, dash_duo):
     plugin = setup_plugin(dash_duo, __name__, ResponseComparison)
     wanted_ensemble_name = "nr_42"

--- a/tests/views/test_observation_view.py
+++ b/tests/views/test_observation_view.py
@@ -8,6 +8,7 @@ from tests.conftest import (
 )
 
 
+@pytest.mark.browser_test
 def test_observation_analyzer_view_ensemble_no_observations(
     mock_data,
     dash_duo,
@@ -29,6 +30,7 @@ def test_observation_analyzer_view_ensemble_no_observations(
     # assert dash_duo.get_logs() == [], "browser console should contain no error"
 
 
+@pytest.mark.browser_test
 def test_observation_analyzer_view_ensemble_with_observations(
     mock_data,
     dash_duo,

--- a/tests/views/test_parameter_selector.py
+++ b/tests/views/test_parameter_selector.py
@@ -5,6 +5,7 @@ from webviz_ert.plugins import ParameterComparison
 from tests.conftest import setup_plugin, select_ensemble, select_by_name
 
 
+@pytest.mark.browser_test
 def test_parameter_selector(
     mock_data,
     dash_duo,
@@ -57,6 +58,7 @@ def test_parameter_selector(
     # assert dash_duo.get_logs() == []
 
 
+@pytest.mark.browser_test
 def test_search_input_return_functionality(
     mock_data,
     dash_duo,
@@ -128,6 +130,7 @@ def test_search_input_return_functionality(
     # assert dash_duo.get_logs() == []
 
 
+@pytest.mark.browser_test
 def test_parameter_selector_sorting(
     mock_data,
     dash_duo,

--- a/tests/views/test_plot_view.py
+++ b/tests/views/test_plot_view.py
@@ -1,3 +1,4 @@
+import pytest
 from webviz_ert.plugins._response_comparison import ResponseComparison
 from tests.conftest import (
     setup_plugin,
@@ -8,6 +9,7 @@ from tests.conftest import (
 )
 
 
+@pytest.mark.browser_test
 def test_plot_view(
     mock_data,
     dash_duo,
@@ -26,6 +28,7 @@ def test_plot_view(
     # assert dash_duo.get_logs() == [], "browser console should contain no error"
 
 
+@pytest.mark.browser_test
 def test_clearing_parameters_view(
     mock_data,
     dash_duo,
@@ -60,6 +63,7 @@ def test_clearing_parameters_view(
     # assert dash_duo.get_logs() == [], "browser console should contain no error"
 
 
+@pytest.mark.browser_test
 def test_clearing_ensembles_view(
     mock_data,
     dash_duo,
@@ -108,6 +112,7 @@ def test_clearing_ensembles_view(
     # assert dash_duo.get_logs() == [], "browser console should contain no error"
 
 
+@pytest.mark.browser_test
 def test_axis_labels(mock_data, dash_duo):
     """test_axis_labels loads two different plots in the plot view and checks
     that axes are labelled correctly"""

--- a/tests/views/test_response_correlation.py
+++ b/tests/views/test_response_correlation.py
@@ -1,3 +1,4 @@
+import pytest
 from webviz_ert.plugins._response_correlation import ResponseCorrelation
 from tests.conftest import (
     setup_plugin,
@@ -8,6 +9,7 @@ from tests.conftest import (
 )
 
 
+@pytest.mark.browser_test
 def test_axes_labels(mock_data, dash_duo):
     """test_axis_labels loads two different plots and checks that axes are
     labelled correctly"""
@@ -53,6 +55,7 @@ def test_axes_labels(mock_data, dash_duo):
     # assert dash_duo.get_logs() == [], "browser console should contain no error"
 
 
+@pytest.mark.browser_test
 def test_show_respo_with_obs(mock_data, dash_duo):
     """Test response observation filter works as expected"""
     plugin = setup_plugin(dash_duo, __name__, ResponseCorrelation)
@@ -70,6 +73,7 @@ def test_show_respo_with_obs(mock_data, dash_duo):
     )
 
 
+@pytest.mark.browser_test
 def test_info_text_appears_as_expected(
     mock_data,
     dash_duo,

--- a/tests/views/test_state_saving.py
+++ b/tests/views/test_state_saving.py
@@ -1,3 +1,4 @@
+import pytest
 from webviz_ert.plugins import (
     ResponseComparison,
     WebvizErtPluginABC,
@@ -12,6 +13,7 @@ from tests.conftest import (
 )
 
 
+@pytest.mark.browser_test
 def test_state_saved(mock_data, dash_duo, tmpdir):
     root_path = tmpdir.strpath
     plugin = setup_plugin(


### PR DESCRIPTION
**Issue**
Resolves #446


**Approach**
Following the issue's comment made by @kwinkunks
 "But we could mark tests requiring the driver, however, so that if situations like this happen again, we can easily turn off the tests temporarily.", the approach went on marking the tests that requires dash / Selenium as "browser-test", which can be skipped with the command "pytest --skip-browser-tests". 


## Pre review checklist

- [ ] Added appropriate labels
