### PR TITLE
Fix numpy warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "setuptools_scm"]
 
 [tool.pytest.ini_options]
 addopts = "-m 'not spe1'"

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,6 +5,6 @@ black
 scipy
 dash[testing]>=2.5.1
 selenium
-urllib3<2 # RHEL7 does not support urllib >= 2.0
+urllib3<2 # Pinned to make Snyk happy. Also indirectly pinned due to restrictions in other test deps.
 flask>=2.2.5 # not directly required, pinned by Snyk to avoid a vulnerability
 werkzeug>=3.0.6 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/webviz_ert/models/plot_model.py
+++ b/webviz_ert/models/plot_model.py
@@ -471,8 +471,10 @@ class HistogramPlotModel:
     def repr(self) -> go.Figure:
         bin_count = int(math.ceil(math.sqrt(len(self.data_df.values.flatten()))))
         bin_size = float(
-            (self.data_df.max(axis=1).values - self.data_df.min(axis=1).values)
-            / bin_count
+            (
+                (self.data_df.max(axis=1).values - self.data_df.min(axis=1).values)
+                / bin_count
+            )[0]
         )
         fig = ff.create_distplot(
             [list(self.data_df.values.flatten())],


### PR DESCRIPTION
Fixups warnings. Tests will still install old urllib3 due to constraints with selenium and wekzeugs apparently, but seems difficult if not impossible to fix at the moment.
